### PR TITLE
feat: add basic infrastructure for Tenstorrent Wormhole NPU support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
+ "serde_json",
  "sysinfo",
  "tokio",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 axum = "0.8.4"
 tower-http = { version = "0.6.6", features = ["cors", "trace"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 reqwest = { version = "0.12", features = ["json"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -106,8 +106,8 @@ pub async fn metrics_handler(State(state): State<SharedState>) -> String {
             ));
         }
 
-        // Add GPU info metric with device type and vendor-specific information
-        metrics.push_str("# HELP all_smi_gpu_info GPU device information\n");
+        // Add GPU/NPU info metric with device type and vendor-specific information
+        metrics.push_str("# HELP all_smi_gpu_info GPU/NPU device information\n");
         metrics.push_str("# TYPE all_smi_gpu_info info\n");
 
         // Build label string
@@ -217,6 +217,19 @@ pub async fn metrics_handler(State(state): State<SharedState>) -> String {
                         info.name, info.instance, info.uuid, i, state_num
                     ));
                 }
+            }
+        }
+
+        // NPU-specific metrics (Furiosa)
+        if info.device_type == "NPU" {
+            // Add NPU-specific firmware version as a dedicated metric
+            if let Some(firmware) = info.detail.get("firmware") {
+                metrics.push_str("# HELP all_smi_npu_firmware_info NPU firmware version\n");
+                metrics.push_str("# TYPE all_smi_npu_firmware_info info\n");
+                metrics.push_str(&format!(
+                    "all_smi_npu_firmware_info{{npu=\"{}\", instance=\"{}\", uuid=\"{}\", index=\"{}\", firmware=\"{}\"}} 1\n",
+                    info.name, info.instance, info.uuid, i, firmware
+                ));
             }
         }
     }

--- a/src/device/furiosa.rs
+++ b/src/device/furiosa.rs
@@ -1,0 +1,38 @@
+use crate::device::{GpuInfo, GpuReader, ProcessInfo};
+use std::process::Command;
+
+pub struct FuriosaReader;
+
+impl FuriosaReader {
+    pub fn new() -> Self {
+        FuriosaReader
+    }
+
+    fn parse_furiosactl_output(&self, _output: &str) -> Vec<GpuInfo> {
+        // TODO: Parse furiosactl output to extract NPU information
+        // This will be implemented once we know the exact output format
+        vec![]
+    }
+
+    fn get_furiosa_processes(&self) -> Vec<ProcessInfo> {
+        // TODO: Get processes using Furiosa NPUs
+        vec![]
+    }
+}
+
+impl GpuReader for FuriosaReader {
+    fn get_gpu_info(&self) -> Vec<GpuInfo> {
+        // Run furiosactl to get NPU information
+        match Command::new("furiosactl").arg("info").output() {
+            Ok(output) => {
+                let output_str = String::from_utf8_lossy(&output.stdout);
+                self.parse_furiosactl_output(&output_str)
+            }
+            Err(_) => vec![],
+        }
+    }
+
+    fn get_process_info(&self) -> Vec<ProcessInfo> {
+        self.get_furiosa_processes()
+    }
+}

--- a/src/device/furiosa.rs
+++ b/src/device/furiosa.rs
@@ -1,38 +1,147 @@
 use crate::device::{GpuInfo, GpuReader, ProcessInfo};
 use std::process::Command;
 
-pub struct FuriosaReader;
+/// Collection method for Furiosa NPU metrics
+#[derive(Debug, Clone, Copy)]
+pub enum CollectionMethod {
+    /// Use furiosactl command-line tool
+    Furiosactl,
+    /// Read directly from device files in /dev
+    DeviceFile,
+}
+
+/// Configuration for Furiosa reader
+pub struct FuriosaConfig {
+    /// Primary method to use for collecting metrics
+    pub primary_method: CollectionMethod,
+    /// Fallback method if primary fails
+    pub fallback_method: Option<CollectionMethod>,
+}
+
+impl Default for FuriosaConfig {
+    fn default() -> Self {
+        Self {
+            primary_method: CollectionMethod::Furiosactl,
+            fallback_method: Some(CollectionMethod::DeviceFile),
+        }
+    }
+}
+
+pub struct FuriosaReader {
+    config: FuriosaConfig,
+}
 
 impl FuriosaReader {
     pub fn new() -> Self {
-        FuriosaReader
+        Self::with_config(FuriosaConfig::default())
     }
 
+    pub fn with_config(config: FuriosaConfig) -> Self {
+        FuriosaReader { config }
+    }
+
+    /// Collect NPU info using the configured method with fallback
+    fn collect_npu_info(&self) -> Vec<GpuInfo> {
+        // Try primary method first
+        let mut result = match self.config.primary_method {
+            CollectionMethod::Furiosactl => self.collect_via_furiosactl(),
+            CollectionMethod::DeviceFile => self.collect_via_device_files(),
+        };
+
+        // If primary method failed and we have a fallback, try it
+        if result.is_empty() {
+            if let Some(fallback) = self.config.fallback_method {
+                eprintln!(
+                    "Primary method {:?} failed, trying fallback {:?}",
+                    self.config.primary_method, fallback
+                );
+                result = match fallback {
+                    CollectionMethod::Furiosactl => self.collect_via_furiosactl(),
+                    CollectionMethod::DeviceFile => self.collect_via_device_files(),
+                };
+            }
+        }
+
+        result
+    }
+
+    /// Collect NPU information using furiosactl
+    fn collect_via_furiosactl(&self) -> Vec<GpuInfo> {
+        match Command::new("furiosactl").arg("info").output() {
+            Ok(output) => {
+                if output.status.success() {
+                    let output_str = String::from_utf8_lossy(&output.stdout);
+                    self.parse_furiosactl_output(&output_str)
+                } else {
+                    eprintln!(
+                        "furiosactl command failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    vec![]
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to execute furiosactl: {e}");
+                vec![]
+            }
+        }
+    }
+
+    /// Collect NPU information by reading device files
+    fn collect_via_device_files(&self) -> Vec<GpuInfo> {
+        // TODO: Implement device file reading
+        // This will read from /dev/furiosa* or similar device files
+        eprintln!("Device file collection not yet implemented");
+        vec![]
+    }
+
+    /// Parse furiosactl output to extract NPU information
     fn parse_furiosactl_output(&self, _output: &str) -> Vec<GpuInfo> {
         // TODO: Parse furiosactl output to extract NPU information
         // This will be implemented once we know the exact output format
         vec![]
     }
 
-    fn get_furiosa_processes(&self) -> Vec<ProcessInfo> {
-        // TODO: Get processes using Furiosa NPUs
+    /// Get processes using Furiosa NPUs via furiosactl
+    fn get_furiosa_processes_via_furiosactl(&self) -> Vec<ProcessInfo> {
+        // TODO: Get processes using Furiosa NPUs via furiosactl
         vec![]
+    }
+
+    /// Get processes using Furiosa NPUs via device files
+    fn get_furiosa_processes_via_device_files(&self) -> Vec<ProcessInfo> {
+        // TODO: Get processes using Furiosa NPUs via /dev
+        vec![]
+    }
+
+    /// Collect process info using the configured method with fallback
+    fn collect_process_info(&self) -> Vec<ProcessInfo> {
+        // Try primary method first
+        let mut result = match self.config.primary_method {
+            CollectionMethod::Furiosactl => self.get_furiosa_processes_via_furiosactl(),
+            CollectionMethod::DeviceFile => self.get_furiosa_processes_via_device_files(),
+        };
+
+        // If primary method failed and we have a fallback, try it
+        if result.is_empty() {
+            if let Some(fallback) = self.config.fallback_method {
+                result = match fallback {
+                    CollectionMethod::Furiosactl => self.get_furiosa_processes_via_furiosactl(),
+                    CollectionMethod::DeviceFile => self.get_furiosa_processes_via_device_files(),
+                };
+            }
+        }
+
+        result
     }
 }
 
 impl GpuReader for FuriosaReader {
     fn get_gpu_info(&self) -> Vec<GpuInfo> {
-        // Run furiosactl to get NPU information
-        match Command::new("furiosactl").arg("info").output() {
-            Ok(output) => {
-                let output_str = String::from_utf8_lossy(&output.stdout);
-                self.parse_furiosactl_output(&output_str)
-            }
-            Err(_) => vec![],
-        }
+        self.collect_npu_info()
     }
 
     fn get_process_info(&self) -> Vec<ProcessInfo> {
-        self.get_furiosa_processes()
+        self.collect_process_info()
     }
 }

--- a/src/device/furiosa.rs
+++ b/src/device/furiosa.rs
@@ -1,4 +1,8 @@
 use crate::device::{GpuInfo, GpuReader, ProcessInfo};
+use crate::utils::get_hostname;
+use chrono::Local;
+use serde::Deserialize;
+use std::collections::HashMap;
 use std::process::Command;
 
 /// Collection method for Furiosa NPU metrics
@@ -8,6 +12,45 @@ pub enum CollectionMethod {
     Furiosactl,
     /// Read directly from device files in /dev
     DeviceFile,
+}
+
+/// JSON structure for furiosactl info output
+#[derive(Debug, Deserialize)]
+struct FuriosaInfoJson {
+    dev_name: String,
+    product_name: String,
+    device_uuid: String,
+    device_sn: String,
+    firmware: String,
+    temperature: String,
+    power: String,
+    clock: String,
+    pci_bdf: String,
+    pci_dev: String,
+}
+
+/// JSON structure for furiosactl list output
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct FuriosaListJson {
+    npu: String,
+    cores: Vec<FuriosaCoreInfo>,
+    devfiles: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct FuriosaCoreInfo {
+    idx: u32,
+    status: String,
+}
+
+/// JSON structure for furiosactl ps output
+#[derive(Debug, Deserialize)]
+struct FuriosaProcessJson {
+    npu: String,
+    pid: u32,
+    cmd: String,
 }
 
 /// Configuration for Furiosa reader
@@ -40,6 +83,73 @@ impl FuriosaReader {
         FuriosaReader { config }
     }
 
+    /// Extract base NPU name from device string
+    /// e.g., "npu0pe0-1" -> "npu0"
+    fn get_base_npu_name(device: &str) -> String {
+        if let Some(idx) = device.find("pe") {
+            device[..idx].to_string()
+        } else {
+            device.to_string()
+        }
+    }
+
+    /// Get NPU utilization from furiosactl top (single sample)
+    fn get_npu_utilization(&self) -> Option<HashMap<String, f64>> {
+        use std::io::{BufRead, BufReader};
+        use std::process::Stdio;
+
+        // Run furiosactl top with a short interval to get one sample
+        let mut child = Command::new("furiosactl")
+            .args(["top", "--interval", "100"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+
+        let stdout = child.stdout.take()?;
+        let reader = BufReader::new(stdout);
+        let mut utilization_map = HashMap::new();
+        let mut lines_read = 0;
+
+        // Read a few lines to get utilization data
+        for line in reader.lines().map_while(Result::ok) {
+            if line.contains("Device") && line.contains("NPU(%)") {
+                // Skip header line
+                continue;
+            }
+
+            // Parse data line: "2023-03-21T09:45:56.699483936Z  152616    npu1pe0-1      19.06    100.00     0.00   ./npu_runtime_test"
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 6 {
+                if let (Some(device), Some(npu_util)) = (parts.get(2), parts.get(3)) {
+                    if let Ok(util) = npu_util.parse::<f64>() {
+                        let base_npu = Self::get_base_npu_name(device);
+                        // Store the maximum utilization for each NPU
+                        utilization_map
+                            .entry(base_npu)
+                            .and_modify(|e: &mut f64| *e = e.max(util))
+                            .or_insert(util);
+                    }
+                }
+            }
+
+            lines_read += 1;
+            if lines_read > 10 {
+                break;
+            }
+        }
+
+        // Kill the process after getting some data
+        let _ = child.kill();
+        let _ = child.wait();
+
+        if utilization_map.is_empty() {
+            None
+        } else {
+            Some(utilization_map)
+        }
+    }
+
     /// Collect NPU info using the configured method with fallback
     fn collect_npu_info(&self) -> Vec<GpuInfo> {
         // Try primary method first
@@ -67,11 +177,25 @@ impl FuriosaReader {
 
     /// Collect NPU information using furiosactl
     fn collect_via_furiosactl(&self) -> Vec<GpuInfo> {
-        match Command::new("furiosactl").arg("info").output() {
+        match Command::new("furiosactl")
+            .args(["info", "--format", "json"])
+            .output()
+        {
             Ok(output) => {
                 if output.status.success() {
                     let output_str = String::from_utf8_lossy(&output.stdout);
-                    self.parse_furiosactl_output(&output_str)
+                    let mut devices = self.parse_furiosactl_info_json(&output_str);
+
+                    // Try to get utilization data
+                    if let Some(utilization_map) = self.get_npu_utilization() {
+                        for device in &mut devices {
+                            if let Some(util) = utilization_map.get(&device.instance) {
+                                device.utilization = *util;
+                            }
+                        }
+                    }
+
+                    devices
                 } else {
                     eprintln!(
                         "furiosactl command failed: {}",
@@ -95,17 +219,150 @@ impl FuriosaReader {
         vec![]
     }
 
-    /// Parse furiosactl output to extract NPU information
-    fn parse_furiosactl_output(&self, _output: &str) -> Vec<GpuInfo> {
-        // TODO: Parse furiosactl output to extract NPU information
-        // This will be implemented once we know the exact output format
-        vec![]
+    /// Parse furiosactl info JSON output
+    fn parse_furiosactl_info_json(&self, output: &str) -> Vec<GpuInfo> {
+        match serde_json::from_str::<Vec<FuriosaInfoJson>>(output) {
+            Ok(devices) => {
+                let hostname = get_hostname();
+                let time = Local::now().format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+
+                devices
+                    .into_iter()
+                    .map(|device| {
+                        let mut detail = HashMap::new();
+                        detail.insert("serial_number".to_string(), device.device_sn);
+                        detail.insert("firmware".to_string(), device.firmware);
+                        detail.insert("pci_address".to_string(), device.pci_bdf);
+                        detail.insert("pci_device".to_string(), device.pci_dev);
+
+                        // Parse temperature (remove °C suffix)
+                        let temperature = device
+                            .temperature
+                            .trim_end_matches("°C")
+                            .parse::<u32>()
+                            .unwrap_or(0);
+
+                        // Parse power (remove W suffix)
+                        let power = device
+                            .power
+                            .trim_end_matches(" W")
+                            .parse::<f64>()
+                            .unwrap_or(0.0);
+
+                        // Parse frequency (remove MHz suffix)
+                        let frequency = device
+                            .clock
+                            .trim_end_matches(" MHz")
+                            .parse::<u32>()
+                            .unwrap_or(0);
+
+                        GpuInfo {
+                            uuid: device.device_uuid,
+                            time: time.clone(),
+                            name: format!("Furiosa {}", device.product_name),
+                            device_type: "NPU".to_string(),
+                            hostname: hostname.clone(),
+                            instance: device.dev_name.clone(),
+                            utilization: 0.0, // TODO: Get from furiosactl top or other source
+                            ane_utilization: 0.0,
+                            dla_utilization: None,
+                            temperature,
+                            used_memory: 0,  // TODO: Get memory info when available
+                            total_memory: 0, // TODO: Get memory info when available
+                            frequency,
+                            power_consumption: power,
+                            detail,
+                        }
+                    })
+                    .collect()
+            }
+            Err(e) => {
+                eprintln!("Failed to parse furiosactl JSON output: {e}");
+                vec![]
+            }
+        }
     }
 
     /// Get processes using Furiosa NPUs via furiosactl
     fn get_furiosa_processes_via_furiosactl(&self) -> Vec<ProcessInfo> {
-        // TODO: Get processes using Furiosa NPUs via furiosactl
-        vec![]
+        match Command::new("furiosactl")
+            .args(["ps", "--format", "json"])
+            .output()
+        {
+            Ok(output) => {
+                if output.status.success() {
+                    let output_str = String::from_utf8_lossy(&output.stdout);
+                    self.parse_furiosactl_ps_json(&output_str)
+                } else {
+                    eprintln!(
+                        "furiosactl ps failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    vec![]
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to execute furiosactl ps: {e}");
+                vec![]
+            }
+        }
+    }
+
+    /// Parse furiosactl ps JSON output
+    fn parse_furiosactl_ps_json(&self, output: &str) -> Vec<ProcessInfo> {
+        match serde_json::from_str::<Vec<FuriosaProcessJson>>(output) {
+            Ok(processes) => {
+                processes
+                    .into_iter()
+                    .map(|proc| {
+                        let base_npu = Self::get_base_npu_name(&proc.npu);
+
+                        // Extract process name from command
+                        let process_name = proc
+                            .cmd
+                            .split_whitespace()
+                            .next()
+                            .and_then(|cmd| cmd.split('/').next_back())
+                            .unwrap_or("unknown")
+                            .to_string();
+
+                        // Get system process info if available
+                        let sys_info =
+                            crate::device::process_utils::get_system_process_info(proc.pid);
+
+                        ProcessInfo {
+                            device_id: 0, // TODO: Map NPU name to device index
+                            device_uuid: base_npu,
+                            pid: proc.pid,
+                            process_name,
+                            used_memory: 0, // TODO: Get from actual data when available
+                            cpu_percent: sys_info.as_ref().map(|s| s.0).unwrap_or(0.0),
+                            memory_percent: sys_info.as_ref().map(|s| s.1).unwrap_or(0.0),
+                            memory_rss: sys_info.as_ref().map(|s| s.2).unwrap_or(0),
+                            memory_vms: sys_info.as_ref().map(|s| s.3).unwrap_or(0),
+                            user: sys_info.as_ref().map(|s| s.4.clone()).unwrap_or_default(),
+                            state: sys_info.as_ref().map(|s| s.5.clone()).unwrap_or_default(),
+                            start_time: sys_info.as_ref().map(|s| s.6.clone()).unwrap_or_default(),
+                            cpu_time: sys_info.as_ref().map(|s| s.7).unwrap_or(0),
+                            command: proc.cmd,
+                            ppid: sys_info.as_ref().map(|s| s.9).unwrap_or(0),
+                            threads: sys_info.as_ref().map(|s| s.10).unwrap_or(0),
+                            uses_gpu: true, // Using NPU
+                            priority: 0,
+                            nice_value: 0,
+                            gpu_utilization: 0.0, // TODO: Get from furiosactl top
+                        }
+                    })
+                    .collect()
+            }
+            Err(e) => {
+                // Empty array is valid JSON, no need to log error
+                if output.trim() != "[]" {
+                    eprintln!("Failed to parse furiosactl ps JSON output: {e}");
+                }
+                vec![]
+            }
+        }
     }
 
     /// Get processes using Furiosa NPUs via device files

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -3,6 +3,7 @@ pub mod apple_silicon;
 pub mod furiosa;
 pub mod nvidia;
 pub mod nvidia_jetson;
+pub mod tenstorrent;
 
 // Re-export NVML status function for UI
 pub use nvidia::get_nvml_status_message;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "macos")]
 pub mod apple_silicon;
+pub mod furiosa;
 pub mod nvidia;
 pub mod nvidia_jetson;
 

--- a/src/device/platform_detection.rs
+++ b/src/device/platform_detection.rs
@@ -26,6 +26,11 @@ pub fn has_furiosa() -> bool {
     Command::new("furiosactl").output().is_ok()
 }
 
+pub fn has_tenstorrent() -> bool {
+    // Check if tt-smi or tensix-stat is available
+    Command::new("tt-smi").output().is_ok() || Command::new("tensix-stat").output().is_ok()
+}
+
 pub fn get_os_type() -> &'static str {
     std::env::consts::OS
 }

--- a/src/device/platform_detection.rs
+++ b/src/device/platform_detection.rs
@@ -21,6 +21,11 @@ pub fn is_apple_silicon() -> bool {
     architecture.trim() == "arm64"
 }
 
+pub fn has_furiosa() -> bool {
+    // Check if furiosactl is available
+    Command::new("furiosactl").output().is_ok()
+}
+
 pub fn get_os_type() -> &'static str {
     std::env::consts::OS
 }

--- a/src/device/reader_factory.rs
+++ b/src/device/reader_factory.rs
@@ -1,6 +1,6 @@
 use crate::device::{
-    nvidia, nvidia_jetson,
-    platform_detection::{get_os_type, has_nvidia, is_jetson},
+    furiosa, nvidia, nvidia_jetson,
+    platform_detection::{get_os_type, has_furiosa, has_nvidia, is_jetson},
     traits::{CpuReader, GpuReader, MemoryReader},
 };
 
@@ -20,6 +20,11 @@ pub fn get_gpu_readers() -> Vec<Box<dyn GpuReader>> {
                 readers.push(Box::new(nvidia_jetson::NvidiaJetsonGpuReader {}));
             } else if has_nvidia() {
                 readers.push(Box::new(nvidia::NvidiaGpuReader {}));
+            }
+
+            // Check for Furiosa NPU support
+            if has_furiosa() {
+                readers.push(Box::new(furiosa::FuriosaReader::new()));
             }
         }
         "macos" =>

--- a/src/device/reader_factory.rs
+++ b/src/device/reader_factory.rs
@@ -1,6 +1,7 @@
 use crate::device::{
     furiosa, nvidia, nvidia_jetson,
-    platform_detection::{get_os_type, has_furiosa, has_nvidia, is_jetson},
+    platform_detection::{get_os_type, has_furiosa, has_nvidia, has_tenstorrent, is_jetson},
+    tenstorrent,
     traits::{CpuReader, GpuReader, MemoryReader},
 };
 
@@ -25,6 +26,11 @@ pub fn get_gpu_readers() -> Vec<Box<dyn GpuReader>> {
             // Check for Furiosa NPU support
             if has_furiosa() {
                 readers.push(Box::new(furiosa::FuriosaReader::new()));
+            }
+
+            // Check for Tenstorrent NPU support
+            if has_tenstorrent() {
+                readers.push(Box::new(tenstorrent::TenstorrentReader::new()));
             }
         }
         "macos" =>

--- a/src/device/tenstorrent.rs
+++ b/src/device/tenstorrent.rs
@@ -1,0 +1,224 @@
+use crate::device::{GpuInfo, GpuReader, ProcessInfo};
+use crate::utils::get_hostname;
+use chrono::Local;
+use std::collections::HashMap;
+use std::process::Command;
+
+/// Collection method for Tenstorrent NPU metrics
+#[derive(Debug, Clone, Copy)]
+pub enum CollectionMethod {
+    /// Use tt-smi command-line tool
+    TtSmi,
+    /// Read directly from device files in /dev
+    DeviceFile,
+}
+
+/// Configuration for Tenstorrent reader
+pub struct TenstorrentConfig {
+    /// Primary method to use for collecting metrics
+    pub primary_method: CollectionMethod,
+    /// Fallback method if primary fails
+    pub fallback_method: Option<CollectionMethod>,
+}
+
+impl Default for TenstorrentConfig {
+    fn default() -> Self {
+        Self {
+            primary_method: CollectionMethod::TtSmi,
+            fallback_method: Some(CollectionMethod::DeviceFile),
+        }
+    }
+}
+
+pub struct TenstorrentReader {
+    config: TenstorrentConfig,
+}
+
+impl TenstorrentReader {
+    pub fn new() -> Self {
+        Self::with_config(TenstorrentConfig::default())
+    }
+
+    pub fn with_config(config: TenstorrentConfig) -> Self {
+        TenstorrentReader { config }
+    }
+
+    /// Extract base device name from Tenstorrent device string
+    /// e.g., "wh0" or similar patterns
+    #[allow(dead_code)]
+    fn get_base_device_name(device: &str) -> String {
+        device.to_string()
+    }
+
+    /// Collect NPU info using the configured method with fallback
+    fn collect_npu_info(&self) -> Vec<GpuInfo> {
+        // Try primary method first
+        let mut result = match self.config.primary_method {
+            CollectionMethod::TtSmi => self.collect_via_tt_smi(),
+            CollectionMethod::DeviceFile => self.collect_via_device_files(),
+        };
+
+        // If primary method failed and we have a fallback, try it
+        if result.is_empty() {
+            if let Some(fallback) = self.config.fallback_method {
+                eprintln!(
+                    "Primary method {:?} failed, trying fallback {:?}",
+                    self.config.primary_method, fallback
+                );
+                result = match fallback {
+                    CollectionMethod::TtSmi => self.collect_via_tt_smi(),
+                    CollectionMethod::DeviceFile => self.collect_via_device_files(),
+                };
+            }
+        }
+
+        result
+    }
+
+    /// Collect NPU information using tt-smi
+    fn collect_via_tt_smi(&self) -> Vec<GpuInfo> {
+        // Try tt-smi first
+        match Command::new("tt-smi").output() {
+            Ok(output) => {
+                if output.status.success() {
+                    let output_str = String::from_utf8_lossy(&output.stdout);
+                    return self.parse_tt_smi_output(&output_str);
+                } else {
+                    eprintln!(
+                        "tt-smi command failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to execute tt-smi: {e}");
+            }
+        }
+
+        // If tt-smi fails, try tensix-stat as alternative
+        match Command::new("tensix-stat").output() {
+            Ok(output) => {
+                if output.status.success() {
+                    let output_str = String::from_utf8_lossy(&output.stdout);
+                    self.parse_tensix_stat_output(&output_str)
+                } else {
+                    eprintln!(
+                        "tensix-stat command failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    vec![]
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to execute tensix-stat: {e}");
+                vec![]
+            }
+        }
+    }
+
+    /// Collect NPU information by reading device files
+    fn collect_via_device_files(&self) -> Vec<GpuInfo> {
+        // TODO: Implement device file reading
+        // This will read from /dev/tenstorrent* or similar device files
+        eprintln!("Device file collection not yet implemented for Tenstorrent");
+        vec![]
+    }
+
+    /// Parse tt-smi output
+    fn parse_tt_smi_output(&self, _output: &str) -> Vec<GpuInfo> {
+        // TODO: Parse tt-smi output to extract NPU information
+        // This will be implemented once we know the exact output format
+        let hostname = get_hostname();
+        let time = Local::now().format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+
+        // Placeholder implementation
+        // Real implementation would parse the actual output
+        vec![GpuInfo {
+            uuid: "TT-PLACEHOLDER-UUID".to_string(),
+            time,
+            name: "Tenstorrent Wormhole".to_string(),
+            device_type: "NPU".to_string(),
+            hostname: hostname.clone(),
+            instance: "wh0".to_string(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: 0.0,
+            detail: HashMap::new(),
+        }]
+    }
+
+    /// Parse tensix-stat output
+    fn parse_tensix_stat_output(&self, _output: &str) -> Vec<GpuInfo> {
+        // TODO: Parse tensix-stat output to extract NPU information
+        // This will be implemented once we know the exact output format
+        let hostname = get_hostname();
+        let time = Local::now().format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+
+        // Placeholder implementation
+        vec![GpuInfo {
+            uuid: "TT-PLACEHOLDER-UUID".to_string(),
+            time,
+            name: "Tenstorrent Wormhole".to_string(),
+            device_type: "NPU".to_string(),
+            hostname: hostname.clone(),
+            instance: "wh0".to_string(),
+            utilization: 0.0,
+            ane_utilization: 0.0,
+            dla_utilization: None,
+            temperature: 0,
+            used_memory: 0,
+            total_memory: 0,
+            frequency: 0,
+            power_consumption: 0.0,
+            detail: HashMap::new(),
+        }]
+    }
+
+    /// Get processes using Tenstorrent NPUs via tt-smi
+    fn get_processes_via_tt_smi(&self) -> Vec<ProcessInfo> {
+        // TODO: Get processes using Tenstorrent NPUs via tt-smi
+        vec![]
+    }
+
+    /// Get processes using Tenstorrent NPUs via device files
+    fn get_processes_via_device_files(&self) -> Vec<ProcessInfo> {
+        // TODO: Get processes using Tenstorrent NPUs via /dev
+        vec![]
+    }
+
+    /// Collect process info using the configured method with fallback
+    fn collect_process_info(&self) -> Vec<ProcessInfo> {
+        // Try primary method first
+        let mut result = match self.config.primary_method {
+            CollectionMethod::TtSmi => self.get_processes_via_tt_smi(),
+            CollectionMethod::DeviceFile => self.get_processes_via_device_files(),
+        };
+
+        // If primary method failed and we have a fallback, try it
+        if result.is_empty() {
+            if let Some(fallback) = self.config.fallback_method {
+                result = match fallback {
+                    CollectionMethod::TtSmi => self.get_processes_via_tt_smi(),
+                    CollectionMethod::DeviceFile => self.get_processes_via_device_files(),
+                };
+            }
+        }
+
+        result
+    }
+}
+
+impl GpuReader for TenstorrentReader {
+    fn get_gpu_info(&self) -> Vec<GpuInfo> {
+        self.collect_npu_info()
+    }
+
+    fn get_process_info(&self) -> Vec<ProcessInfo> {
+        self.collect_process_info()
+    }
+}

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -46,7 +46,10 @@ impl MetricsParser {
                 }
 
                 // Process different metric types
-                if metric_name.starts_with("gpu_") || metric_name == "ane_utilization" {
+                if metric_name.starts_with("gpu_")
+                    || metric_name.starts_with("npu_")
+                    || metric_name == "ane_utilization"
+                {
                     self.process_gpu_metrics(&mut gpu_info_map, metric_name, &labels, value, host);
                 } else if metric_name.starts_with("cpu_") {
                     self.process_cpu_metrics(&mut cpu_info_map, metric_name, &labels, value, host);
@@ -180,6 +183,35 @@ impl MetricsParser {
                     gpu_info
                         .detail
                         .insert("compute_capability".to_string(), compute_cap.clone());
+                }
+                // Extract NPU-specific info
+                if let Some(firmware) = labels.get("firmware") {
+                    gpu_info
+                        .detail
+                        .insert("firmware".to_string(), firmware.clone());
+                }
+                if let Some(serial_number) = labels.get("serial_number") {
+                    gpu_info
+                        .detail
+                        .insert("serial_number".to_string(), serial_number.clone());
+                }
+                if let Some(pci_address) = labels.get("pci_address") {
+                    gpu_info
+                        .detail
+                        .insert("pci_address".to_string(), pci_address.clone());
+                }
+                if let Some(pci_device) = labels.get("pci_device") {
+                    gpu_info
+                        .detail
+                        .insert("pci_device".to_string(), pci_device.clone());
+                }
+            }
+            "npu_firmware_info" => {
+                // Handle NPU-specific firmware info metric
+                if let Some(firmware) = labels.get("firmware") {
+                    gpu_info
+                        .detail
+                        .insert("firmware".to_string(), firmware.clone());
                 }
             }
             _ => {}


### PR DESCRIPTION
## Summary
- Added basic infrastructure to support Tenstorrent Wormhole NPU devices
- Created new `tenstorrent` module with dual-method collection support
- Added platform detection for Tenstorrent devices via `tt-smi` or `tensix-stat` commands
- Integrated Tenstorrent support into the reader factory for Linux systems

## Implementation Details
- **New Module**: `src/device/tenstorrent.rs` - Contains the `TenstorrentReader` struct with dual collection methods
- **Collection Methods**: 
  - Primary: `tt-smi` command-line tool (with fallback to `tensix-stat`)
  - Fallback: Direct device file reading from `/dev/tenstorrent*` (placeholder)
- **Platform Detection**: Added `has_tenstorrent()` function to check for tool availability
- **Reader Factory**: Updated to instantiate `TenstorrentReader` when Tenstorrent NPUs are detected
- **Module Exports**: Added tenstorrent module to device mod.rs

## Architecture
The implementation follows the same dual-method pattern as Furiosa support:
- Configurable primary and fallback collection methods
- Automatic fallback when primary method fails
- NPUs will appear with "NPU" device type in the UI
- Ready for API mode and remote monitoring

## Next Steps
The basic abstraction layer is now in place. Future work will include:
- Implementing actual parsing of `tt-smi` and `tensix-stat` output for device metrics
- Adding process information collection for Tenstorrent NPUs
- Implementing device file reading as the fallback method
- Testing with real Tenstorrent hardware

## Test plan
- [x] Verify the code compiles without errors
- [x] Confirm no regression in existing GPU detection (NVIDIA, Apple Silicon, Jetson, Furiosa)
- [ ] Test on system with Tenstorrent NPU (when available)