### PR TITLE
fix: exclude Docker mounts and sort disk list for consistent ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,3 @@ mock = []
 name = "all-smi-mock-server"
 path = "src/bin/all-smi-mock-server.rs"
 required-features = ["mock"]
-
-[[bin]]
-name = "debug-disks"
-path = "src/bin/debug-disks.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,7 @@ mock = []
 name = "all-smi-mock-server"
 path = "src/bin/all-smi-mock-server.rs"
 required-features = ["mock"]
+
+[[bin]]
+name = "debug-disks"
+path = "src/bin/debug-disks.rs"

--- a/src/utils/disk_filter.rs
+++ b/src/utils/disk_filter.rs
@@ -64,6 +64,10 @@ impl DiskFilter {
         exact.insert("/Volumes"); // Empty volumes directory
         prefixes.insert("/Network/");
 
+        // Docker paths on macOS
+        prefixes.insert("/var/lib/docker/");
+        exact.insert("/var/lib/docker");
+
         exact.insert("/Users/Shared");
         exact.insert("/cores");
     }
@@ -106,11 +110,17 @@ impl DiskFilter {
 
     fn add_common_exclusions(
         prefixes: &mut HashSet<&'static str>,
-        _exact: &mut HashSet<&'static str>,
+        exact: &mut HashSet<&'static str>,
     ) {
         // Common runtime and temporary directories
         prefixes.insert("/tmp/");
         prefixes.insert("/var/tmp/");
+
+        // Docker-specific paths (common across platforms)
+        prefixes.insert("/var/lib/docker/");
+        exact.insert("/var/lib/docker");
+        prefixes.insert("/var/lib/containerd/");
+        exact.insert("/var/lib/containerd");
     }
 
     fn add_docker_exclusions(docker_mounts: &mut HashSet<&'static str>) {
@@ -180,9 +190,11 @@ pub fn filter_docker_aware_disks(disks: &Disks) -> Vec<&Disk> {
         }
     }
 
-    // Special case: always include overlay filesystem (Docker container root)
+    // Special case: include overlay filesystem (Docker container root) if it passes basic filter
     for disk in disks.list() {
+        let mount_point = disk.mount_point().to_string_lossy().to_string();
         if (disk.file_system() == "overlay" || disk.file_system() == "overlay2")
+            && filter.should_include(&mount_point)
             && !filtered_disks
                 .iter()
                 .any(|d| d.mount_point() == disk.mount_point())
@@ -273,6 +285,8 @@ mod tests {
         assert!(!filter.should_include("/Library/Preferences"));
         assert!(!filter.should_include("/Applications/Safari.app"));
         assert!(!filter.should_include("/Users/Shared"));
+        assert!(!filter.should_include("/var/lib/docker"));
+        assert!(!filter.should_include("/var/lib/docker/volumes"));
 
         // Should include user and data paths
         assert!(filter.should_include("/Users/john"));

--- a/src/utils/disk_filter.rs
+++ b/src/utils/disk_filter.rs
@@ -85,7 +85,12 @@ impl DiskFilter {
         prefixes.insert("/var/tmp/");
         prefixes.insert("/var/spool/");
 
+        // Docker-specific paths
+        prefixes.insert("/var/lib/docker/");
+        exact.insert("/var/lib/docker");
+
         exact.insert("/boot");
+        exact.insert("/boot/efi");
         exact.insert("/tmp");
         exact.insert("/bin");
         exact.insert("/sbin");
@@ -286,6 +291,9 @@ mod tests {
         assert!(!filter.should_include("/run/user/1000"));
         assert!(!filter.should_include("/usr/bin"));
         assert!(!filter.should_include("/var/log/syslog"));
+        assert!(!filter.should_include("/var/lib/docker"));
+        assert!(!filter.should_include("/var/lib/docker/volumes"));
+        assert!(!filter.should_include("/boot/efi"));
 
         // Should include user and data paths
         assert!(filter.should_include("/home/user"));


### PR DESCRIPTION
## Summary
- Fixed Docker mount paths appearing in disk list by adding proper exclusions
- Implemented disk sorting to maintain consistent ordering across refreshes
- Fixed overlay filesystem bypass that was including Docker container mounts

## Changes
- Added `/var/lib/docker` and `/var/lib/containerd` to exclusion lists across all platforms
- Fixed overlay filesystem special case to respect basic filtering
- Implemented alphabetical sorting by mount point for consistent disk list ordering
- Added sorting by hostname first, then mount point for remote monitoring mode

## Test Plan
- [x] Tested disk filtering with debug tool - Docker mounts properly excluded
- [x] Verified consistent disk ordering across multiple refreshes
- [x] Confirmed API endpoints exclude Docker mounts in Prometheus metrics
- [x] Tested on Linux server with active Docker containers