### PR TITLE
fix: multi-node view connection issues and performance improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ on:
         options:
           - 'true'
           - 'false'
+      release_tag:
+        description: 'Release tag to upload artifacts to (e.g. v1.2.3)'
+        required: false
 
 # Required permissions for release uploads
 permissions:
@@ -204,9 +207,10 @@ jobs:
     # Step 9: Upload binary to GitHub Release
     # ───────────────────────────────────────────────────────────────
     - name: Upload release artifact
-      if: github.event_name == 'release'
+      if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
       uses: softprops/action-gh-release@v2
       with:
+        tag_name: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
         files: ${{ matrix.asset_name }}${{ matrix.archive_ext }}
 
   # ═══════════════════════════════════════════════════════════════

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,10 @@ jobs:
       matrix:
         include:
           # Linux x86_64 (glibc)
+          # Uses Ubuntu 22.04 for compatibility
+          # with most glibc-based systems
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact_name: all-smi
             asset_name: all-smi-linux-x86_64
             cross: false
@@ -61,8 +63,10 @@ jobs:
             archive_ext: ".tar.gz"
           
           # Linux ARM64 (glibc)
+          # Uses Ubuntu 22.04 for compatibility
+          # with most glibc-based systems
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm
             artifact_name: all-smi
             asset_name: all-smi-linux-aarch64
             cross: false

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,27 @@
+.PHONY: help local remote mock release test lint clean
+
+help:
+	@echo "all-smi"
+	@echo ""
+	@echo "Available targets:"
+	@echo ""
+	@echo "Setup & Building:"
+	@echo "  local                Run for local view mode"
+	@echo "  remote               Run for remote view mode"
+	@echo "  mock                 Run mock server for testing"
+	@echo ""
+	@echo "Quality & Testing:"
+	@echo "  test                 Run tests"
+	@echo ""
+	@echo "Quality & Testing:"
+	@echo "  validate             Validate links and content"
+	@echo "  lint                 Run linting on documentation"
+	@echo "  test                 Run all tests"
+	@echo ""
+	@echo "Deployment:"
+	@echo "  release              Build release binaries"
+	@echo "  clean                Clean build artifacts"
+
 local:
 	cargo run --bin all-smi -- view 
 
@@ -12,3 +36,10 @@ release:
 
 test:
 	cargo test --all
+
+lint:
+	cargo fmt --features=all -- --check
+	cargo clippy --features=all -- -D warnings
+
+clean:
+	cargo clean

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 #[derive(Clone, Debug)]
 pub struct ConnectionStatus {
-    pub hostname: String, // This is the server address key (e.g., "localhost:10001")
+    pub host_id: String, // This is the server address key (e.g., "localhost:10001")
     #[allow(dead_code)]
     pub url: String,
     pub actual_hostname: Option<String>, // The real hostname from API (e.g., "node-0001")
@@ -19,9 +19,9 @@ pub struct ConnectionStatus {
 }
 
 impl ConnectionStatus {
-    pub fn new(hostname: String, url: String) -> Self {
+    pub fn new(host_id: String, url: String) -> Self {
         Self {
-            hostname,
+            host_id,
             url,
             actual_hostname: None,
             is_connected: false,
@@ -76,7 +76,7 @@ pub struct AppState {
     pub tab_scroll_offset: usize,
     pub process_horizontal_scroll_offset: usize,
     pub device_name_scroll_offsets: HashMap<String, usize>,
-    pub hostname_scroll_offsets: HashMap<String, usize>,
+    pub host_id_scroll_offsets: HashMap<String, usize>,
     pub frame_counter: u64,
     pub storage_info: Vec<StorageInfo>,
     pub show_help: bool,
@@ -149,7 +149,7 @@ impl AppState {
             tab_scroll_offset: 0,
             process_horizontal_scroll_offset: 0,
             device_name_scroll_offsets: HashMap::new(),
-            hostname_scroll_offsets: HashMap::new(),
+            host_id_scroll_offsets: HashMap::new(),
             frame_counter: 0,
             storage_info: Vec::new(),
             show_help: false,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -89,6 +89,8 @@ pub struct AppState {
     // Connection status tracking for remote mode
     pub connection_status: HashMap<String, ConnectionStatus>,
     pub known_hosts: Vec<String>,
+    // Reverse lookup: actual_hostname -> host_id for efficient connection status retrieval
+    pub hostname_to_host_id: HashMap<String, String>,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -160,6 +162,7 @@ impl AppState {
             // Connection status tracking for remote mode
             connection_status: HashMap::new(),
             known_hosts: Vec::new(),
+            hostname_to_host_id: HashMap::new(),
         }
     }
 }

--- a/src/device/apple_silicon.rs
+++ b/src/device/apple_silicon.rs
@@ -109,7 +109,8 @@ impl GpuReader for AppleSiliconGpuReader {
             time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
             name: self.name.clone(),
             device_type: "GPU".to_string(),
-            hostname: get_hostname(),
+            host_id: get_hostname(), // For local mode, host_id is just the hostname
+            hostname: get_hostname(), // DNS hostname
             instance: get_hostname(),
             utilization: metrics.utilization.unwrap_or(0.0),
             ane_utilization: metrics.ane_utilization.unwrap_or(0.0),

--- a/src/device/cpu_linux.rs
+++ b/src/device/cpu_linux.rs
@@ -56,6 +56,7 @@ impl LinuxCpuReader {
         let power_consumption = None;
 
         Ok(CpuInfo {
+            host_id: hostname.clone(), // For local mode, host_id is just the hostname
             hostname,
             instance,
             cpu_model,

--- a/src/device/cpu_macos.rs
+++ b/src/device/cpu_macos.rs
@@ -131,6 +131,7 @@ impl MacOsCpuReader {
         }];
 
         Ok(CpuInfo {
+            host_id: hostname.clone(), // For local mode, host_id is just the hostname
             hostname,
             instance,
             cpu_model,
@@ -189,6 +190,7 @@ impl MacOsCpuReader {
         }
 
         Ok(CpuInfo {
+            host_id: hostname.clone(), // For local mode, host_id is just the hostname
             hostname,
             instance,
             cpu_model,

--- a/src/device/furiosa.rs
+++ b/src/device/furiosa.rs
@@ -261,7 +261,8 @@ impl FuriosaReader {
                             time: time.clone(),
                             name: format!("Furiosa {}", device.product_name),
                             device_type: "NPU".to_string(),
-                            hostname: hostname.clone(),
+                            host_id: hostname.clone(), // For local mode, host_id is just the hostname
+                            hostname: hostname.clone(), // DNS hostname
                             instance: device.dev_name.clone(),
                             utilization: 0.0, // TODO: Get from furiosactl top or other source
                             ane_utilization: 0.0,

--- a/src/device/memory_linux.rs
+++ b/src/device/memory_linux.rs
@@ -61,6 +61,7 @@ impl MemoryReader for LinuxMemoryReader {
             let now = Local::now();
 
             memory_info.push(MemoryInfo {
+                host_id: hostname.clone(), // For local mode, host_id is just the hostname
                 hostname: hostname.clone(),
                 instance: hostname,
                 total_bytes,

--- a/src/device/memory_macos.rs
+++ b/src/device/memory_macos.rs
@@ -76,6 +76,7 @@ impl MemoryReader for MacOsMemoryReader {
                 let now = Local::now();
 
                 memory_info.push(MemoryInfo {
+                    host_id: hostname.clone(), // For local mode, host_id is just the hostname
                     hostname: hostname.clone(),
                     instance: hostname,
                     total_bytes,

--- a/src/device/nvidia.rs
+++ b/src/device/nvidia.rs
@@ -346,7 +346,8 @@ impl NvidiaGpuReader {
                         time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
                         name: device.name().unwrap_or_else(|_| "Unknown GPU".to_string()),
                         device_type: "GPU".to_string(),
-                        hostname: get_hostname(),
+                        host_id: get_hostname(), // For local mode, host_id is just the hostname
+                        hostname: get_hostname(), // DNS hostname
                         instance: get_hostname(),
                         utilization: device
                             .utilization_rates()
@@ -445,7 +446,8 @@ impl NvidiaGpuReader {
                             time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
                             name,
                             device_type: "GPU".to_string(),
-                            hostname: get_hostname(),
+                            host_id: get_hostname(), // For local mode, host_id is just the hostname
+                            hostname: get_hostname(), // DNS hostname
                             instance: get_hostname(),
                             utilization,
                             ane_utilization: 0.0,

--- a/src/device/nvidia_jetson.rs
+++ b/src/device/nvidia_jetson.rs
@@ -93,7 +93,8 @@ impl GpuReader for NvidiaJetsonGpuReader {
             time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
             name,
             device_type: "GPU".to_string(),
-            hostname: get_hostname(),
+            host_id: get_hostname(), // For local mode, host_id is just the hostname
+            hostname: get_hostname(), // DNS hostname
             instance: get_hostname(),
             utilization,
             ane_utilization: 0.0,

--- a/src/device/tenstorrent.rs
+++ b/src/device/tenstorrent.rs
@@ -516,7 +516,8 @@ impl TenstorrentReader {
                     time,
                     name: static_info.device_name.clone(),
                     device_type: "NPU".to_string(),
-                    hostname: hostname.clone(),
+                    host_id: hostname.clone(), // For local mode, host_id is just the hostname
+                    hostname: hostname.clone(), // DNS hostname
                     instance: format!("tt{index}"),
                     utilization,
                     ane_utilization: 0.0,

--- a/src/device/types.rs
+++ b/src/device/types.rs
@@ -23,8 +23,9 @@ pub struct GpuInfo {
     pub time: String,
     pub name: String,
     pub device_type: String, // "GPU", "NPU", etc.
-    pub hostname: String,
-    pub instance: String,
+    pub host_id: String,     // Host identifier (e.g., "10.82.128.41:9090")
+    pub hostname: String,    // DNS hostname of the server
+    pub instance: String,    // Instance name from metrics
     pub utilization: f64,
     pub ane_utilization: f64,
     pub dla_utilization: Option<f64>,
@@ -62,8 +63,9 @@ pub struct ProcessInfo {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CpuInfo {
-    pub hostname: String,
-    pub instance: String,
+    pub host_id: String,  // Host identifier (e.g., "10.82.128.41:9090")
+    pub hostname: String, // DNS hostname of the server
+    pub instance: String, // Instance name from metrics
     pub cpu_model: String,
     pub architecture: String, // "x86_64", "arm64", etc.
     pub platform_type: CpuPlatformType,
@@ -114,8 +116,9 @@ pub struct AppleSiliconCpuInfo {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MemoryInfo {
-    pub hostname: String,
-    pub instance: String,
+    pub host_id: String,       // Host identifier (e.g., "10.82.128.41:9090")
+    pub hostname: String,      // DNS hostname of the server
+    pub instance: String,      // Instance name from metrics
     pub total_bytes: u64,      // Total system memory in bytes
     pub used_bytes: u64,       // Used memory in bytes
     pub available_bytes: u64,  // Available memory in bytes

--- a/src/metrics/aggregator.rs
+++ b/src/metrics/aggregator.rs
@@ -269,6 +269,7 @@ mod tests {
             time: "2024-01-01 00:00:00".to_string(),
             name: "Test GPU".to_string(),
             device_type: "GPU".to_string(),
+            host_id: "test-host".to_string(),
             hostname: "test-host".to_string(),
             instance: "test-instance".to_string(),
             utilization: 75.0,

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures_util::stream::{FuturesUnordered, StreamExt};
 use regex::Regex;
 
 use crate::app_state::ConnectionStatus;
@@ -46,140 +47,152 @@ impl NetworkClient {
 
         // Parallel data collection with concurrency limiting and retries
         let total_hosts = hosts.len();
-        let fetch_tasks: Vec<_> = hosts
-            .iter()
-            .enumerate()
-            .map(|(i, host)| {
-                let client = self.client.clone();
-                let host = host.clone();
-                let semaphore = semaphore.clone();
-                tokio::spawn(async move {
-                    // Stagger connection attempts to avoid overwhelming the listen queue
-                    let stagger_delay = EnvConfig::connection_stagger_delay(i, total_hosts);
-                    tokio::time::sleep(Duration::from_millis(stagger_delay)).await;
+        let mut fetch_futures = FuturesUnordered::new();
 
-                    // Acquire semaphore permit to limit concurrency
-                    let _permit = semaphore.acquire().await.unwrap();
+        for (i, host) in hosts.iter().enumerate() {
+            let client = self.client.clone();
+            let host = host.clone();
+            let semaphore = semaphore.clone();
 
-                    let url = if host.starts_with("http://") || host.starts_with("https://") {
-                        format!("{host}/metrics")
-                    } else {
-                        format!("http://{host}/metrics")
-                    };
+            let future = tokio::spawn(async move {
+                // Stagger connection attempts to avoid overwhelming the listen queue
+                let stagger_delay = EnvConfig::connection_stagger_delay(i, total_hosts);
+                tokio::time::sleep(Duration::from_millis(stagger_delay)).await;
 
-                    // Retry logic with exponential backoff
-                    for attempt in 1..=AppConfig::RETRY_ATTEMPTS {
-                        match client.get(&url).send().await {
-                            Ok(response) => {
-                                if response.status().is_success() {
-                                    match response.text().await {
-                                        Ok(text) => return Some((host, text, None)),
-                                        Err(e) => {
-                                            if attempt == 3 {
-                                                return Some((
-                                                    host,
-                                                    String::new(),
-                                                    Some(format!("Text parse error: {e}")),
-                                                ));
-                                            }
+                // Acquire semaphore permit to limit concurrency
+                let _permit = semaphore.acquire().await.unwrap();
+
+                let url = if host.starts_with("http://") || host.starts_with("https://") {
+                    format!("{host}/metrics")
+                } else {
+                    format!("http://{host}/metrics")
+                };
+
+                // Retry logic with exponential backoff
+                for attempt in 1..=AppConfig::RETRY_ATTEMPTS {
+                    match client.get(&url).send().await {
+                        Ok(response) => {
+                            if response.status().is_success() {
+                                match response.text().await {
+                                    Ok(text) => return Some((host, text, None)),
+                                    Err(e) => {
+                                        if attempt == 3 {
+                                            return Some((
+                                                host,
+                                                String::new(),
+                                                Some(format!("Text parse error: {e}")),
+                                            ));
                                         }
                                     }
-                                } else if attempt == 3 {
-                                    return Some((
-                                        host,
-                                        String::new(),
-                                        Some(format!("HTTP {}", response.status())),
-                                    ));
                                 }
-                            }
-                            Err(e) => {
-                                if attempt == 3 {
-                                    return Some((
-                                        host,
-                                        String::new(),
-                                        Some(format!(
-                                            "Connection error after {attempt} attempts: {e}"
-                                        )),
-                                    ));
-                                }
+                            } else if attempt == 3 {
+                                return Some((
+                                    host,
+                                    String::new(),
+                                    Some(format!("HTTP {}", response.status())),
+                                ));
                             }
                         }
-
-                        // Exponential backoff
-                        tokio::time::sleep(Duration::from_millis(EnvConfig::retry_delay(attempt)))
-                            .await;
+                        Err(e) => {
+                            if attempt == 3 {
+                                return Some((
+                                    host,
+                                    String::new(),
+                                    Some(format!("Connection error after {attempt} attempts: {e}")),
+                                ));
+                            }
+                        }
                     }
 
-                    Some((
-                        host,
-                        String::new(),
-                        Some("All retry attempts failed".to_string()),
-                    ))
-                })
-            })
-            .collect();
+                    // Exponential backoff
+                    tokio::time::sleep(Duration::from_millis(EnvConfig::retry_delay(attempt)))
+                        .await;
+                }
 
-        // Wait for all fetch tasks to complete
-        let fetch_results = futures_util::future::join_all(fetch_tasks).await;
+                Some((
+                    host,
+                    String::new(),
+                    Some("All retry attempts failed".to_string()),
+                ))
+            });
 
-        // Process all fetch results with connection status tracking
+            fetch_futures.push(future);
+        }
+
+        // Process results as they arrive using streaming with overall timeout
         let mut _successful_connections = 0;
         let mut _failed_connections = 0;
-        for task_result in fetch_results {
-            match task_result {
-                Ok(Some((host, text, error))) => {
-                    let host_identifier = host.clone();
-                    let mut connection_status =
-                        ConnectionStatus::new(host_identifier.clone(), host.clone());
 
-                    if let Some(error_msg) = error {
-                        _failed_connections += 1;
-                        connection_status.mark_failure(error_msg);
-                        connection_statuses.push(connection_status);
-                        continue;
+        // Set overall timeout for collecting results (4 seconds)
+        let overall_timeout = Duration::from_secs(4);
+        let timeout_future = tokio::time::sleep(overall_timeout);
+        tokio::pin!(timeout_future);
+
+        loop {
+            tokio::select! {
+                // Process next result if available
+                Some(task_result) = fetch_futures.next() => {
+                    match task_result {
+                        Ok(Some((host, text, error))) => {
+                            let host_identifier = host.clone();
+                            let mut connection_status =
+                                ConnectionStatus::new(host_identifier.clone(), host.clone());
+
+                            if let Some(error_msg) = error {
+                                _failed_connections += 1;
+                                connection_status.mark_failure(error_msg);
+                                connection_statuses.push(connection_status);
+                                continue;
+                            }
+
+                            _successful_connections += 1;
+                            connection_status.mark_success();
+
+                            if text.is_empty() {
+                                connection_statuses.push(connection_status);
+                                continue;
+                            }
+
+                            let parser = super::metrics_parser::MetricsParser::new();
+                            let (gpu_info, cpu_info, memory_info, storage_info) =
+                                parser.parse_metrics(&text, &host, re);
+
+                            // Extract the actual hostname from device info if available
+                            let actual_hostname = if let Some(first_gpu) = gpu_info.first() {
+                                Some(first_gpu.hostname.clone())
+                            } else if let Some(first_cpu) = cpu_info.first() {
+                                Some(first_cpu.hostname.clone())
+                            } else if let Some(first_memory) = memory_info.first() {
+                                Some(first_memory.hostname.clone())
+                            } else {
+                                storage_info
+                                    .first()
+                                    .map(|first_storage| first_storage.hostname.clone())
+                            };
+
+                            // Store the actual hostname while keeping the URL as the key
+                            connection_status.actual_hostname = actual_hostname;
+                            connection_statuses.push(connection_status);
+
+                            all_gpu_info.extend(gpu_info);
+                            all_cpu_info.extend(cpu_info);
+                            all_memory_info.extend(memory_info);
+                            all_storage_info.extend(storage_info);
+                        }
+                        Ok(None) => {
+                            _failed_connections += 1;
+                            // We don't have host information for None results, so we can't create a connection status
+                        }
+                        Err(_) => {
+                            _failed_connections += 1;
+                            // We don't have host information for Err results, so we can't create a connection status
+                        }
                     }
-
-                    _successful_connections += 1;
-                    connection_status.mark_success();
-
-                    if text.is_empty() {
-                        connection_statuses.push(connection_status);
-                        continue;
-                    }
-
-                    let parser = super::metrics_parser::MetricsParser::new();
-                    let (gpu_info, cpu_info, memory_info, storage_info) =
-                        parser.parse_metrics(&text, &host, re);
-
-                    // Extract the actual hostname from device info if available
-                    let actual_hostname = if let Some(first_gpu) = gpu_info.first() {
-                        Some(first_gpu.hostname.clone())
-                    } else if let Some(first_cpu) = cpu_info.first() {
-                        Some(first_cpu.hostname.clone())
-                    } else if let Some(first_memory) = memory_info.first() {
-                        Some(first_memory.hostname.clone())
-                    } else {
-                        storage_info
-                            .first()
-                            .map(|first_storage| first_storage.hostname.clone())
-                    };
-
-                    // Store the actual hostname while keeping the URL as the key
-                    connection_status.actual_hostname = actual_hostname;
-                    connection_statuses.push(connection_status);
-
-                    all_gpu_info.extend(gpu_info);
-                    all_cpu_info.extend(cpu_info);
-                    all_memory_info.extend(memory_info);
-                    all_storage_info.extend(storage_info);
                 }
-                Ok(None) => {
-                    _failed_connections += 1;
-                    // We don't have host information for None results, so we can't create a connection status
-                }
-                Err(_) => {
-                    _failed_connections += 1;
-                    // We don't have host information for Err results, so we can't create a connection status
+                // Timeout reached - return partial results
+                _ = &mut timeout_future => {
+                    // Mark remaining hosts as timed out
+                    break;
                 }
             }
         }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -157,21 +157,15 @@ impl NetworkClient {
                             let (gpu_info, cpu_info, memory_info, storage_info) =
                                 parser.parse_metrics(&text, &host, re);
 
-                            // Extract the actual hostname from device info if available
-                            let actual_hostname = if let Some(first_gpu) = gpu_info.first() {
-                                Some(first_gpu.hostname.clone())
+                            // Extract the instance name from device info if available
+                            let instance_name = if let Some(first_gpu) = gpu_info.first() {
+                                Some(first_gpu.instance.clone())
                             } else if let Some(first_cpu) = cpu_info.first() {
-                                Some(first_cpu.hostname.clone())
-                            } else if let Some(first_memory) = memory_info.first() {
-                                Some(first_memory.hostname.clone())
-                            } else {
-                                storage_info
-                                    .first()
-                                    .map(|first_storage| first_storage.hostname.clone())
-                            };
+                                Some(first_cpu.instance.clone())
+                            } else { memory_info.first().map(|first_memory| first_memory.instance.clone()) };
 
-                            // Store the actual hostname while keeping the URL as the key
-                            connection_status.actual_hostname = actual_hostname;
+                            // Store the instance name as actual_hostname for display purposes
+                            connection_status.actual_hostname = instance_name;
                             connection_statuses.push(connection_status);
 
                             all_gpu_info.extend(gpu_info);

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -129,7 +129,11 @@ impl MetricsParser {
                 time: Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
                 name: gpu_name,
                 device_type: "GPU".to_string(), // Default to GPU, can be overridden by gpu_info metric
-                hostname: host.to_string(),     // Use full host address as key
+                host_id: host.to_string(),      // Host identifier (e.g., "10.82.128.41:9090")
+                hostname: labels
+                    .get("instance")
+                    .cloned()
+                    .unwrap_or_else(|| host.to_string()), // DNS hostname from instance label
                 instance: labels
                     .get("instance")
                     .cloned()
@@ -247,7 +251,11 @@ impl MetricsParser {
             };
 
             CpuInfo {
-                hostname: host.to_string(), // Use full host address as key
+                host_id: host.to_string(), // Host identifier (e.g., "10.82.128.41:9090")
+                hostname: labels
+                    .get("instance")
+                    .cloned()
+                    .unwrap_or_else(|| host.to_string()), // DNS hostname from instance label
                 instance: labels
                     .get("instance")
                     .cloned()
@@ -324,7 +332,11 @@ impl MetricsParser {
         let memory_info = memory_info_map
             .entry(memory_key)
             .or_insert_with(|| MemoryInfo {
-                hostname: host.to_string(), // Use full host address as key
+                host_id: host.to_string(), // Host identifier (e.g., "10.82.128.41:9090")
+                hostname: labels
+                    .get("instance")
+                    .cloned()
+                    .unwrap_or_else(|| host.to_string()), // DNS hostname from instance label
                 instance: labels
                     .get("instance")
                     .cloned()
@@ -373,7 +385,11 @@ impl MetricsParser {
         let storage_info = storage_info_map
             .entry(storage_key)
             .or_insert_with(|| StorageInfo {
-                hostname: host.to_string(), // Use full host address as key
+                host_id: host.to_string(), // Host identifier (e.g., "10.82.128.41:9090")
+                hostname: labels
+                    .get("instance")
+                    .cloned()
+                    .unwrap_or_else(|| host.to_string()), // DNS hostname from instance label
                 mount_point: mount_point.clone(),
                 total_bytes: 0,
                 available_bytes: 0,
@@ -489,7 +505,8 @@ all_smi_ane_utilization{gpu="NVIDIA H200 141GB HBM3", instance="node-0058", uuid
         let gpu = &gpu_info[0];
         assert_eq!(gpu.uuid, "GPU-12345");
         assert_eq!(gpu.name, "NVIDIA H200 141GB HBM3");
-        assert_eq!(gpu.hostname, host);
+        assert_eq!(gpu.host_id, host);
+        assert_eq!(gpu.hostname, "node-0058");
         assert_eq!(gpu.instance, "node-0058");
         assert_eq!(gpu.utilization, 25.5);
         assert_eq!(gpu.used_memory, 8589934592);
@@ -519,7 +536,8 @@ all_smi_cpu_power_consumption_watts{cpu_model="Intel Xeon", instance="node-0058"
 
         assert_eq!(cpu_info.len(), 1);
         let cpu = &cpu_info[0];
-        assert_eq!(cpu.hostname, host);
+        assert_eq!(cpu.host_id, host);
+        assert_eq!(cpu.hostname, "node-0058");
         assert_eq!(cpu.instance, "node-0058");
         assert_eq!(cpu.cpu_model, "Intel Xeon");
         assert_eq!(cpu.utilization, 45.2);
@@ -585,7 +603,8 @@ all_smi_memory_utilization{instance="node-0058", hostname="node-0058", index="0"
 
         assert_eq!(memory_info.len(), 1);
         let memory = &memory_info[0];
-        assert_eq!(memory.hostname, host);
+        assert_eq!(memory.host_id, host);
+        assert_eq!(memory.hostname, "node-0058");
         assert_eq!(memory.instance, "node-0058");
         assert_eq!(memory.total_bytes, 137438953472);
         assert_eq!(memory.used_bytes, 68719476736);
@@ -611,7 +630,8 @@ all_smi_disk_available_bytes{instance="node-0058", mount_point="/home", index="1
         assert_eq!(storage_info.len(), 2);
 
         let root_storage = storage_info.iter().find(|s| s.mount_point == "/").unwrap();
-        assert_eq!(root_storage.hostname, host);
+        assert_eq!(root_storage.host_id, host);
+        assert_eq!(root_storage.hostname, "node-0058");
         assert_eq!(root_storage.total_bytes, 4398046511104);
         assert_eq!(root_storage.available_bytes, 891915494941);
         assert_eq!(root_storage.index, 0);
@@ -620,7 +640,8 @@ all_smi_disk_available_bytes{instance="node-0058", mount_point="/home", index="1
             .iter()
             .find(|s| s.mount_point == "/home")
             .unwrap();
-        assert_eq!(home_storage.hostname, host);
+        assert_eq!(home_storage.host_id, host);
+        assert_eq!(home_storage.hostname, "node-0058");
         assert_eq!(home_storage.total_bytes, 1099511627776);
         assert_eq!(home_storage.available_bytes, 549755813888);
         assert_eq!(home_storage.index, 1);
@@ -649,7 +670,8 @@ all_smi_disk_total_bytes{instance="node-0001", mount_point="/", index="0"} 21990
 
         assert_eq!(gpu_info[0].name, "NVIDIA RTX 4090");
         assert_eq!(gpu_info[0].utilization, 75.0);
-        assert_eq!(gpu_info[0].hostname, host);
+        assert_eq!(gpu_info[0].host_id, host);
+        assert_eq!(gpu_info[0].hostname, "node-0001");
         assert_eq!(gpu_info[0].instance, "node-0001");
 
         assert_eq!(cpu_info[0].cpu_model, "AMD Ryzen");
@@ -711,9 +733,11 @@ all_smi_cpu_utilization{cpu_model="Intel Xeon", instance="production-node-42", h
 
         let (gpu_info, cpu_info, _, _) = parser.parse_metrics(test_data, host, &re);
 
-        assert_eq!(gpu_info[0].hostname, host);
+        assert_eq!(gpu_info[0].host_id, host);
+        assert_eq!(gpu_info[0].hostname, "production-node-42");
         assert_eq!(gpu_info[0].instance, "production-node-42");
-        assert_eq!(cpu_info[0].hostname, host);
+        assert_eq!(cpu_info[0].host_id, host);
+        assert_eq!(cpu_info[0].hostname, "production-node-42");
         assert_eq!(cpu_info[0].instance, "production-node-42");
     }
 

--- a/src/network/metrics_parser.rs
+++ b/src/network/metrics_parser.rs
@@ -489,7 +489,8 @@ all_smi_ane_utilization{gpu="NVIDIA H200 141GB HBM3", instance="node-0058", uuid
         let gpu = &gpu_info[0];
         assert_eq!(gpu.uuid, "GPU-12345");
         assert_eq!(gpu.name, "NVIDIA H200 141GB HBM3");
-        assert_eq!(gpu.hostname, "node-0058");
+        assert_eq!(gpu.hostname, host);
+        assert_eq!(gpu.instance, "node-0058");
         assert_eq!(gpu.utilization, 25.5);
         assert_eq!(gpu.used_memory, 8589934592);
         assert_eq!(gpu.total_memory, 34359738368);
@@ -518,7 +519,8 @@ all_smi_cpu_power_consumption_watts{cpu_model="Intel Xeon", instance="node-0058"
 
         assert_eq!(cpu_info.len(), 1);
         let cpu = &cpu_info[0];
-        assert_eq!(cpu.hostname, "node-0058");
+        assert_eq!(cpu.hostname, host);
+        assert_eq!(cpu.instance, "node-0058");
         assert_eq!(cpu.cpu_model, "Intel Xeon");
         assert_eq!(cpu.utilization, 45.2);
         assert_eq!(cpu.socket_count, 2);
@@ -583,7 +585,8 @@ all_smi_memory_utilization{instance="node-0058", hostname="node-0058", index="0"
 
         assert_eq!(memory_info.len(), 1);
         let memory = &memory_info[0];
-        assert_eq!(memory.hostname, "node-0058");
+        assert_eq!(memory.hostname, host);
+        assert_eq!(memory.instance, "node-0058");
         assert_eq!(memory.total_bytes, 137438953472);
         assert_eq!(memory.used_bytes, 68719476736);
         assert_eq!(memory.available_bytes, 68719476736);
@@ -608,7 +611,7 @@ all_smi_disk_available_bytes{instance="node-0058", mount_point="/home", index="1
         assert_eq!(storage_info.len(), 2);
 
         let root_storage = storage_info.iter().find(|s| s.mount_point == "/").unwrap();
-        assert_eq!(root_storage.hostname, "node-0058");
+        assert_eq!(root_storage.hostname, host);
         assert_eq!(root_storage.total_bytes, 4398046511104);
         assert_eq!(root_storage.available_bytes, 891915494941);
         assert_eq!(root_storage.index, 0);
@@ -617,7 +620,7 @@ all_smi_disk_available_bytes{instance="node-0058", mount_point="/home", index="1
             .iter()
             .find(|s| s.mount_point == "/home")
             .unwrap();
-        assert_eq!(home_storage.hostname, "node-0058");
+        assert_eq!(home_storage.hostname, host);
         assert_eq!(home_storage.total_bytes, 1099511627776);
         assert_eq!(home_storage.available_bytes, 549755813888);
         assert_eq!(home_storage.index, 1);
@@ -646,7 +649,8 @@ all_smi_disk_total_bytes{instance="node-0001", mount_point="/", index="0"} 21990
 
         assert_eq!(gpu_info[0].name, "NVIDIA RTX 4090");
         assert_eq!(gpu_info[0].utilization, 75.0);
-        assert_eq!(gpu_info[0].hostname, "node-0001");
+        assert_eq!(gpu_info[0].hostname, host);
+        assert_eq!(gpu_info[0].instance, "node-0001");
 
         assert_eq!(cpu_info[0].cpu_model, "AMD Ryzen");
         assert_eq!(cpu_info[0].utilization, 60.0);
@@ -707,8 +711,10 @@ all_smi_cpu_utilization{cpu_model="Intel Xeon", instance="production-node-42", h
 
         let (gpu_info, cpu_info, _, _) = parser.parse_metrics(test_data, host, &re);
 
-        assert_eq!(gpu_info[0].hostname, "production-node-42");
-        assert_eq!(cpu_info[0].hostname, "production-node-42");
+        assert_eq!(gpu_info[0].hostname, host);
+        assert_eq!(gpu_info[0].instance, "production-node-42");
+        assert_eq!(cpu_info[0].hostname, host);
+        assert_eq!(cpu_info[0].instance, "production-node-42");
     }
 
     #[test]

--- a/src/storage/info.rs
+++ b/src/storage/info.rs
@@ -5,6 +5,7 @@ pub struct StorageInfo {
     pub mount_point: String,
     pub total_bytes: u64,
     pub available_bytes: u64,
-    pub hostname: String,
+    pub host_id: String,  // Host identifier (e.g., "10.82.128.41:9090")
+    pub hostname: String, // DNS hostname of the server
     pub index: u32,
 }

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -267,10 +267,10 @@ struct NodeViewParams {
 }
 
 fn print_node_view_and_history<W: Write>(stdout: &mut W, state: &AppState, params: NodeViewParams) {
-    // Get nodes (excluding "All" tab)
+    // Get nodes (excluding "All" tab) - these are host addresses
     let nodes: Vec<&String> = state.tabs.iter().skip(1).collect();
 
-    // Calculate per-node utilization
+    // Calculate per-node utilization using host addresses as keys
     let mut node_utils: HashMap<String, f64> = HashMap::new();
     for node in &nodes {
         let node_gpus: Vec<_> = state
@@ -386,18 +386,10 @@ fn print_node_view_row<W: Write>(stdout: &mut W, params: NodeViewRowParams) {
     for (col, node) in row_nodes.iter().enumerate() {
         let util = params.node_utils.get(*node).unwrap_or(&0.0);
 
-        // Find connection status by looking for a status where actual_hostname matches the display name
-        // or where the hostname (URL key) matches if no actual_hostname is set
+        // Look up connection status using the host address (node is a host address)
         let is_connected = params
             .connection_status
-            .values()
-            .find(|status| {
-                if let Some(actual_hostname) = &status.actual_hostname {
-                    actual_hostname == *node
-                } else {
-                    &status.hostname == *node
-                }
-            })
+            .get(*node)
             .map(|status| status.is_connected)
             .unwrap_or(false);
 

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -276,7 +276,7 @@ fn print_node_view_and_history<W: Write>(stdout: &mut W, state: &AppState, param
         let node_gpus: Vec<_> = state
             .gpu_info
             .iter()
-            .filter(|gpu| &gpu.hostname == *node)
+            .filter(|gpu| &gpu.host_id == *node)
             .collect();
         if !node_gpus.is_empty() {
             let node_util =

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -158,7 +158,7 @@ impl LayoutCalculator {
                 state
                     .storage_info
                     .iter()
-                    .filter(|info| info.hostname == *current_hostname)
+                    .filter(|info| info.host_id == *current_hostname)
                     .count()
             } else {
                 0

--- a/src/ui/tabs.rs
+++ b/src/ui/tabs.rs
@@ -192,7 +192,7 @@ mod tests {
             tab_scroll_offset: 0,
             process_horizontal_scroll_offset: 0,
             device_name_scroll_offsets: HashMap::new(),
-            hostname_scroll_offsets: HashMap::new(),
+            host_id_scroll_offsets: HashMap::new(),
             frame_counter: 0,
             storage_info: Vec::new(),
             show_help: false,

--- a/src/view/event_handler.rs
+++ b/src/view/event_handler.rs
@@ -171,7 +171,7 @@ fn handle_down_arrow(state: &mut AppState, args: &ViewArgs) {
             state
                 .gpu_info
                 .iter()
-                .filter(|info| info.hostname == state.tabs[state.current_tab])
+                .filter(|info| info.host_id == state.tabs[state.current_tab])
                 .count()
         };
 
@@ -182,7 +182,7 @@ fn handle_down_arrow(state: &mut AppState, args: &ViewArgs) {
             state
                 .storage_info
                 .iter()
-                .filter(|info| info.hostname == state.tabs[state.current_tab])
+                .filter(|info| info.host_id == state.tabs[state.current_tab])
                 .count()
         };
 
@@ -222,7 +222,7 @@ fn handle_page_up(state: &mut AppState, args: &ViewArgs) {
             state
                 .storage_info
                 .iter()
-                .filter(|info| info.hostname == *current_hostname)
+                .filter(|info| info.host_id == *current_hostname)
                 .count()
         } else {
             0
@@ -266,7 +266,7 @@ fn handle_page_down(state: &mut AppState, args: &ViewArgs) {
             state
                 .storage_info
                 .iter()
-                .filter(|info| info.hostname == *current_hostname)
+                .filter(|info| info.host_id == *current_hostname)
                 .count()
         } else {
             0
@@ -289,7 +289,7 @@ fn handle_page_down(state: &mut AppState, args: &ViewArgs) {
             state
                 .gpu_info
                 .iter()
-                .filter(|info| info.hostname == state.tabs[state.current_tab])
+                .filter(|info| info.host_id == state.tabs[state.current_tab])
                 .count()
         };
 

--- a/src/view/runner.rs
+++ b/src/view/runner.rs
@@ -10,11 +10,7 @@ use crate::view::{
 
 pub async fn run_view_mode(args: &ViewArgs) {
     // Initialize application state
-    let mut initial_state = AppState::new();
-    let is_remote_mode = args.hosts.is_some() || args.hostfile.is_some();
-    if is_remote_mode {
-        initial_state.loading = false;
-    }
+    let initial_state = AppState::new();
 
     let app_state = Arc::new(Mutex::new(initial_state));
 

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -175,7 +175,7 @@ impl UiLoop {
 
     fn update_scroll_offsets(&self, state: &mut AppState) {
         let mut new_device_name_scroll_offsets = state.device_name_scroll_offsets.clone();
-        let mut new_hostname_scroll_offsets = state.hostname_scroll_offsets.clone();
+        let mut new_hostname_scroll_offsets = state.host_id_scroll_offsets.clone();
         let mut processed_hostnames = HashSet::new();
 
         for gpu in &state.gpu_info {
@@ -185,15 +185,15 @@ impl UiLoop {
                     .or_insert(0);
                 *offset = (*offset + 1) % (gpu.name.len() + 3);
             }
-            if gpu.hostname.len() > 9 && processed_hostnames.insert(gpu.hostname.clone()) {
+            if gpu.hostname.len() > 9 && processed_hostnames.insert(gpu.host_id.clone()) {
                 let offset = new_hostname_scroll_offsets
-                    .entry(gpu.hostname.clone())
+                    .entry(gpu.host_id.clone())
                     .or_insert(0);
                 *offset = (*offset + 1) % (gpu.hostname.len() + 3);
             }
         }
         state.device_name_scroll_offsets = new_device_name_scroll_offsets;
-        state.hostname_scroll_offsets = new_hostname_scroll_offsets;
+        state.host_id_scroll_offsets = new_hostname_scroll_offsets;
     }
 
     fn render_help_popup_content(
@@ -293,7 +293,7 @@ impl UiLoop {
                 state
                     .gpu_info
                     .iter()
-                    .filter(|info| info.hostname == state.tabs[state.current_tab])
+                    .filter(|info| info.host_id == state.tabs[state.current_tab])
                     .collect()
             };
 
@@ -327,8 +327,8 @@ impl UiLoop {
                 .copied()
                 .unwrap_or(0);
             let hostname_scroll_offset = state
-                .hostname_scroll_offsets
-                .get(&gpu_info.hostname)
+                .host_id_scroll_offsets
+                .get(&gpu_info.host_id)
                 .copied()
                 .unwrap_or(0);
 
@@ -376,7 +376,7 @@ impl UiLoop {
             let cpu_info_to_display: Vec<_> = state
                 .cpu_info
                 .iter()
-                .filter(|info| info.hostname == *current_hostname)
+                .filter(|info| info.host_id == *current_hostname)
                 .collect();
 
             for (i, cpu_info) in cpu_info_to_display.iter().enumerate() {
@@ -387,7 +387,7 @@ impl UiLoop {
             let memory_info_to_display: Vec<_> = state
                 .memory_info
                 .iter()
-                .filter(|info| info.hostname == *current_hostname)
+                .filter(|info| info.host_id == *current_hostname)
                 .collect();
 
             for (i, memory_info) in memory_info_to_display.iter().enumerate() {
@@ -398,7 +398,7 @@ impl UiLoop {
             let storage_info_to_display: Vec<_> = state
                 .storage_info
                 .iter()
-                .filter(|info| info.hostname == *current_hostname)
+                .filter(|info| info.host_id == *current_hostname)
                 .collect();
 
             let visible_storage = storage_info_to_display

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -349,11 +349,22 @@ impl UiLoop {
             let current_hostname = &state.tabs[state.current_tab];
 
             // Check connection status for the current node
-            let is_connected = state
-                .connection_status
-                .get(current_hostname)
-                .map(|status| status.is_connected)
-                .unwrap_or(true); // Default to connected for local mode
+            let is_connected =
+                if let Some(host_id) = state.hostname_to_host_id.get(current_hostname) {
+                    // Found in reverse lookup, get the connection status
+                    state
+                        .connection_status
+                        .get(host_id)
+                        .map(|status| status.is_connected)
+                        .unwrap_or(false)
+                } else {
+                    // Direct lookup by host_id
+                    state
+                        .connection_status
+                        .get(current_hostname)
+                        .map(|status| status.is_connected)
+                        .unwrap_or(true) // Default to connected for local mode
+                };
 
             if !is_connected {
                 // Show elegant disconnection notification


### PR DESCRIPTION
## Summary
- Fixed multi-node view hanging when monitoring unresponsive servers
- Added automatic protocol stripping from host addresses for consistent key matching
- Improved network fetch performance by exiting early when all hosts respond

## Changes Made

### Connection and Display Issues
- Fixed "CONNECTION LOST" display issue when switching between node tabs
- Implemented proper hostname-to-host mapping for consistent lookups
- Added protocol prefix stripping (http://, https://) from both hosts.csv and command line arguments

### Performance Improvements  
- Changed network client to exit immediately when all hosts have responded instead of waiting for full 4-second timeout
- Implemented streaming results with concurrent connection limiting
- Added connection staggering to prevent overwhelming system listen queues

### Key Improvements
- Host addresses (with ports) are now used as consistent keys throughout the system
- Instance names from metrics are displayed in UI while maintaining host:port as internal keys
- Better handling of connection failures with proper status tracking
- More responsive UI when all nodes are healthy

## Test Plan
- [x] Test with mock servers using various port configurations
- [x] Test with real servers including those with http:// prefix in hosts.csv
- [x] Verify tab switching works correctly in multi-node view
- [x] Confirm early exit behavior when all nodes respond quickly
- [x] Test with mix of responsive and unresponsive nodes