### PR TITLE
feat: add CPU temperature display for non-macOS systems

### DIFF
--- a/src/ui/device_renderers.rs
+++ b/src/ui/device_renderers.rs
@@ -328,6 +328,12 @@ pub fn print_cpu_info<W: Write>(
             None,
         );
     }
+    // Display CPU temperature if available (not on macOS)
+    if let Some(temp) = info.temperature {
+        print_colored_text(stdout, " Temp:", Color::Magenta, None, None);
+        print_colored_text(stdout, &format!("{temp}°C"), Color::White, None, None);
+    }
+
     print_colored_text(stdout, " Cache:", Color::Red, None, None);
     print_colored_text(
         stdout,
@@ -336,13 +342,6 @@ pub fn print_cpu_info<W: Write>(
         None,
         None,
     );
-
-    // Display CPU temperature if available (not on macOS)
-    #[cfg(not(target_os = "macos"))]
-    if let Some(temp) = info.temperature {
-        print_colored_text(stdout, " Temp:", Color::Magenta, None, None);
-        print_colored_text(stdout, &format!("{temp}°C"), Color::White, None, None);
-    }
 
     // Display CPU power if available
     if let Some(power) = info.power_consumption {

--- a/src/ui/device_renderers.rs
+++ b/src/ui/device_renderers.rs
@@ -337,6 +337,13 @@ pub fn print_cpu_info<W: Write>(
         None,
     );
 
+    // Display CPU temperature if available (not on macOS)
+    #[cfg(not(target_os = "macos"))]
+    if let Some(temp) = info.temperature {
+        print_colored_text(stdout, " Temp:", Color::Magenta, None, None);
+        print_colored_text(stdout, &format!("{temp}°C"), Color::White, None, None);
+    }
+
     // Display CPU power if available
     if let Some(power) = info.power_consumption {
         print_colored_text(stdout, " Pwr:", Color::Red, None, None);


### PR DESCRIPTION
## Summary
- Added CPU temperature display in the TUI for Linux and Windows systems
- Temperature is shown after CPU frequency in the format: `Temp: XX°C`
- Temperature display is disabled on macOS using conditional compilation

## Details
This PR adds CPU temperature monitoring to the view mode for non-macOS systems. The temperature reading functionality was already implemented for Linux (reading from thermal zones) and the API metrics were already exporting the temperature data. This change simply adds the temperature to the visual display in the terminal UI.

The implementation:
- Uses `#[cfg(not(target_os = "macos"))]` to conditionally compile the temperature display
- Shows temperature after frequency with the label "Temp:" in magenta color
- Displays the temperature value in Celsius with the °C symbol

Note: CPU temperature reading was already fully implemented in the codebase for Linux systems and the mock server. This PR only adds the visual display of that data in the TUI.

## Test plan
- [x] Build and run on Linux to verify temperature is displayed
- [x] Build and run on macOS to verify temperature is NOT displayed
- [x] Verify mock server still generates CPU temperature metrics
- [x] Verify API mode still exports `all_smi_cpu_temperature_celsius` metric

🤖 Generated with [Claude Code](https://claude.ai/code)