### PR TITLE
fix: use fixed-width formatting for CPU power and temperature display

### DIFF
--- a/src/ui/device_renderers.rs
+++ b/src/ui/device_renderers.rs
@@ -331,7 +331,7 @@ pub fn print_cpu_info<W: Write>(
     // Display CPU temperature if available (not on macOS)
     if let Some(temp) = info.temperature {
         print_colored_text(stdout, " Temp:", Color::Magenta, None, None);
-        print_colored_text(stdout, &format!("{temp}°C"), Color::White, None, None);
+        print_colored_text(stdout, &format!("{temp:>3}°C"), Color::White, None, None);
     }
 
     // Display cache based on platform type
@@ -374,7 +374,7 @@ pub fn print_cpu_info<W: Write>(
     // Display CPU power if available
     if let Some(power) = info.power_consumption {
         print_colored_text(stdout, " Pwr:", Color::Red, None, None);
-        print_colored_text(stdout, &format!("{power:.0}W"), Color::White, None, None);
+        print_colored_text(stdout, &format!("{power:>4.0}W"), Color::White, None, None);
     }
 
     queue!(stdout, Print("\r\n")).unwrap();


### PR DESCRIPTION
## Summary
Fixed display artifact issue where old characters remained visible when CPU power or temperature values changed from double to single digits (e.g., "12W" → "4WW" instead of "4W").

## Changes
- Updated CPU power display to use 4-character fixed-width formatting: `{power:>4.0}W`
- Updated CPU temperature display to use 3-character fixed-width formatting: `{temp:>3}°C`

## Problem
When CPU power changed from values like "12W" to "4W", the display would show "4WW" because the terminal wasn't properly clearing the previous characters. This was due to variable-width formatting that didn't account for the full display area.

## Solution
By using fixed-width formatting with right alignment, the display now properly clears the entire field:
- Power: "12W" → "  4W" (with leading spaces)
- Temperature: "85°C" → " 30°C" (with leading space)

## Test plan
- [x] Test with changing CPU power values (high load → idle)
- [x] Test with changing temperature values
- [x] Verify no display artifacts remain when values decrease in digit count
- [x] Confirm proper alignment in the UI