### PR TITLE
feat: add multi-segment bar visualization with stacked memory display

### DIFF
--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -368,7 +368,7 @@ fn format_terminal_line(cmd: &str, desc: &str, style: &str, width: usize) -> Str
             if cmd.is_empty() {
                 String::new()
             } else {
-                let formatted_cmd = format!("  {:<35}", cmd.white().bold().to_string());
+                let formatted_cmd = format!(" {:<35}", cmd.white().bold().to_string());
                 let formatted_seperator = "#".with(Color::DarkGrey).to_string();
                 let formatted_desc = desc.blue().to_string();
                 format!("{formatted_cmd} {formatted_seperator} {formatted_desc}")

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -207,9 +207,9 @@ fn render_shortcuts_section(
             "legend",
         ),
         ("", "", ""),
-        ("Progress Bar Legend:", "", "header"),
+        ("Resource Gauge Legend:", "", "header"),
         (
-            "  Memory bar:",
+            "  Memory gauge:",
             "[used/buffers/cache                    used%]",
             "membar",
         ),

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -146,10 +146,8 @@ fn render_shortcuts_section(
     state: &AppState,
     is_remote: bool,
 ) -> String {
-    let mut shortcuts_lines = vec![
-        ("", "KEYBOARD SHORTCUTS & NAVIGATION", "title"),
-        ("", "", "separator"),
-        ("", "", ""),
+    // Split content into left and right columns
+    let mut left_column = vec![
         ("Navigation Keys:", "", "header"),
         (
             "  ← →",
@@ -174,13 +172,13 @@ fn render_shortcuts_section(
 
     // Add mode-specific shortcuts
     if !is_remote {
-        shortcuts_lines.extend(vec![
+        left_column.extend(vec![
             ("  P", "Sort processes by PID", "shortcut"),
             ("  M", "Sort processes by memory", "shortcut"),
         ]);
     }
 
-    shortcuts_lines.extend(vec![
+    left_column.extend(vec![
         ("", "", ""),
         ("Process View Columns:", "", "header"),
         ("  PID", "Process ID", "legend"),
@@ -196,7 +194,9 @@ fn render_shortcuts_section(
         ("  VRAM", "GPU memory usage", "legend"),
         ("  TIME+", "Total CPU time used", "legend"),
         ("  Command", "Command line (← → to scroll)", "legend"),
-        ("", "", ""),
+    ]);
+
+    let mut right_column = vec![
         ("Process Color Legend:", "", "header"),
         ("  Your processes", "White text", "legend"),
         ("  Root/unknown", "Dark grey text", "legend"),
@@ -214,17 +214,41 @@ fn render_shortcuts_section(
             "membar",
         ),
         ("", "", ""),
-    ]);
+        ("", "", ""),
+        ("Current Status:", "", "header"),
+    ];
 
     // Add current sort status
     let sort_status = get_current_sort_status(&state.sort_criteria);
-    shortcuts_lines.push(("Current sort:", &sort_status, "status"));
+    right_column.push(("  Sort mode:", &sort_status, "status"));
 
-    if line_idx < shortcuts_lines.len() {
-        let (key, desc, style) = &shortcuts_lines[line_idx];
-        format_shortcut_line(key, desc, style, width)
-    } else {
-        " ".repeat(width)
+    // Handle special rows
+    match line_idx {
+        0 => center_text_colored("KEYBOARD SHORTCUTS & NAVIGATION", width, Color::Yellow),
+        1 => "═".repeat(width).with(Color::DarkGrey).to_string(),
+        2 => " ".repeat(width),
+        _ => {
+            let content_line = line_idx - 3; // Adjust for title and separator
+            let column_width = (width - 4) / 2; // Leave space for middle separator
+
+            // Get content from both columns
+            let left_content = if content_line < left_column.len() {
+                let (key, desc, style) = &left_column[content_line];
+                format_shortcut_line(key, desc, style, column_width)
+            } else {
+                " ".repeat(column_width)
+            };
+
+            let right_content = if content_line < right_column.len() {
+                let (key, desc, style) = &right_column[content_line];
+                format_shortcut_line(key, desc, style, column_width)
+            } else {
+                " ".repeat(column_width)
+            };
+
+            // Combine columns with separator
+            format!("{left_content}  │  {right_content}")
+        }
     }
 }
 
@@ -277,24 +301,56 @@ fn format_shortcut_line(key: &str, desc: &str, style: &str, width: usize) -> Str
     let content = match style {
         "title" => center_text_colored(desc, width, Color::Yellow),
         "separator" => "═".repeat(width).with(Color::DarkGrey).to_string(),
-        "header" => format!("  {}", key.green()),
+        "header" => format!(" {}", key.green()),
         "shortcut" => {
             if key.is_empty() {
                 String::new()
             } else {
-                format!("  {:<12} {}", key.white().bold().to_string(), desc.white())
+                let key_str = key.white().bold().to_string();
+                let desc_str = desc.white().to_string();
+                // Calculate available space for description
+                let key_display_width = calculate_display_width(&key_str) + 1; // +1 for leading space
+                let available_desc_width = width.saturating_sub(key_display_width + 2); // +2 for spaces
+                let truncated_desc = if calculate_display_width(&desc_str) > available_desc_width {
+                    let mut truncated = String::new();
+                    let mut current_width = 0;
+                    for ch in desc.chars() {
+                        let ch_width = char_display_width(ch);
+                        if current_width + ch_width + 3 > available_desc_width {
+                            truncated.push_str("...");
+                            break;
+                        }
+                        truncated.push(ch);
+                        current_width += ch_width;
+                    }
+                    truncated
+                } else {
+                    desc.to_string()
+                };
+                format!(" {:<10} {}", key_str, truncated_desc.white())
             }
         }
-        "legend" => format!("  {:<12} {}", key, desc.white()),
-        "status" => format!("  {:<12} {}", key.cyan().to_string(), desc.yellow()),
+        "legend" => {
+            let available_desc_width = width.saturating_sub(12); // 10 for key + 2 for spacing
+            let truncated_desc = if desc.len() > available_desc_width {
+                format!("{}...", &desc[..available_desc_width.saturating_sub(3)])
+            } else {
+                desc.to_string()
+            };
+            format!(" {:<10} {}", key, truncated_desc.white())
+        }
+        "status" => {
+            let key_str = key.cyan().to_string();
+            let desc_str = desc.yellow().to_string();
+            format!(" {key_str:<10} {desc_str}")
+        }
         "membar" => {
             // Format memory bar with colored segments
-            // Split the description to color individual parts
             let colored_desc = desc
                 .replace("used", &"used".green().to_string())
                 .replace("buffers", &"buffers".blue().to_string())
                 .replace("cache", &"cache".yellow().to_string());
-            format!("  {key:<12} {colored_desc}")
+            format!(" {key:<10} {colored_desc}")
         }
         _ => String::new(),
     };
@@ -307,7 +363,7 @@ fn format_terminal_line(cmd: &str, desc: &str, style: &str, width: usize) -> Str
     let content = match style {
         "title" => center_text_colored(desc, width, Color::Magenta),
         "separator" => "═".repeat(width).with(Color::DarkGrey).to_string(),
-        "header" => format!("  {}", cmd.green()),
+        "header" => format!(" {}", cmd.green()),
         "command" => {
             if cmd.is_empty() {
                 String::new()

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -207,6 +207,13 @@ fn render_shortcuts_section(
             "legend",
         ),
         ("", "", ""),
+        ("Progress Bar Legend:", "", "header"),
+        (
+            "  Memory bar:",
+            "[used/buffers/cache                    used%]",
+            "membar",
+        ),
+        ("", "", ""),
     ]);
 
     // Add current sort status
@@ -280,6 +287,15 @@ fn format_shortcut_line(key: &str, desc: &str, style: &str, width: usize) -> Str
         }
         "legend" => format!("  {:<12} {}", key, desc.white()),
         "status" => format!("  {:<12} {}", key.cyan().to_string(), desc.yellow()),
+        "membar" => {
+            // Format memory bar with colored segments
+            // Split the description to color individual parts
+            let colored_desc = desc
+                .replace("used", &"used".green().to_string())
+                .replace("buffers", &"buffers".blue().to_string())
+                .replace("cache", &"cache".yellow().to_string());
+            format!("  {key:<12} {colored_desc}")
+        }
         _ => String::new(),
     };
 

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -184,18 +184,19 @@ pub fn draw_bar_multi<W: Write>(
 // Helper functions for common use cases
 impl BarSegment {
     // CPU usage helpers
+    // nice
     pub fn cpu_low_priority(value: f64) -> Self {
         Self::new(value, Color::Blue).with_label("low")
     }
-
+    // user
     pub fn cpu_normal(value: f64) -> Self {
         Self::new(value, Color::Green).with_label("normal")
     }
-
+    // system
     pub fn cpu_kernel(value: f64) -> Self {
         Self::new(value, Color::Red).with_label("kernel")
     }
-
+    // steal + guest
     pub fn cpu_virtualized(value: f64) -> Self {
         Self::new(value, Color::DarkBlue).with_label("virtual")
     }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -78,7 +78,7 @@ pub fn draw_bar<W: Write>(
             let char_index = i - text_pos;
             if let Some(ch) = display_text.chars().nth(char_index) {
                 // Always use white for text to ensure readability
-                print_colored_text(stdout, &ch.to_string(), Color::White, None, None);
+                print_colored_text(stdout, &ch.to_string(), Color::Grey, None, None);
             }
         } else if i < filled_width {
             // Print filled area with shorter vertical lines in load color
@@ -158,7 +158,7 @@ pub fn draw_bar_multi<W: Write>(
             // Print text character
             let char_index = i - text_pos;
             if let Some(ch) = display_text.chars().nth(char_index) {
-                print_colored_text(stdout, &ch.to_string(), Color::White, None, None);
+                print_colored_text(stdout, &ch.to_string(), Color::Grey, None, None);
             }
         } else {
             // Find which segment this position belongs to

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -183,21 +183,28 @@ pub fn draw_bar_multi<W: Write>(
 
 // Helper functions for common use cases
 impl BarSegment {
-    // CPU usage helpers
-    // nice
+    // CPU usage helpers (reserved for future use)
+    #[allow(dead_code)]
     pub fn cpu_low_priority(value: f64) -> Self {
+        // nice
         Self::new(value, Color::Blue).with_label("low")
     }
-    // user
+
+    #[allow(dead_code)]
     pub fn cpu_normal(value: f64) -> Self {
+        // user
         Self::new(value, Color::Green).with_label("normal")
     }
-    // system
+
+    #[allow(dead_code)]
     pub fn cpu_kernel(value: f64) -> Self {
+        // system
         Self::new(value, Color::Red).with_label("kernel")
     }
-    // steal + guest
+
+    #[allow(dead_code)]
     pub fn cpu_virtualized(value: f64) -> Self {
+        // steal + guest
         Self::new(value, Color::DarkBlue).with_label("virtual")
     }
 

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -5,6 +5,27 @@ use crossterm::style::Color;
 use crate::common::config::ThemeConfig;
 use crate::ui::text::print_colored_text;
 
+pub struct BarSegment {
+    pub value: f64,
+    pub color: Color,
+    pub label: Option<String>,
+}
+
+impl BarSegment {
+    pub fn new(value: f64, color: Color) -> Self {
+        Self {
+            value,
+            color,
+            label: None,
+        }
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+}
+
 pub fn draw_bar<W: Write>(
     stdout: &mut W,
     label: &str,
@@ -69,4 +90,126 @@ pub fn draw_bar<W: Write>(
     }
 
     print_colored_text(stdout, "]", Color::White, None, None);
+}
+
+pub fn draw_bar_multi<W: Write>(
+    stdout: &mut W,
+    label: &str,
+    segments: &[BarSegment],
+    max_value: f64,
+    width: usize,
+    show_text: Option<String>,
+) {
+    // Format label to exactly 5 characters for consistent alignment
+    let formatted_label = if label.len() > 5 {
+        label[..5].to_string()
+    } else {
+        format!("{label:<5}")
+    };
+    let available_bar_width = width.saturating_sub(9); // 9 for "LABEL: [" and "] " (5 + 4)
+
+    // Calculate total value
+    let total_value: f64 = segments.iter().map(|s| s.value).sum();
+    let total_ratio = (total_value / max_value).min(1.0);
+
+    // Prepare text to display inside the bar
+    let display_text = if let Some(text) = show_text {
+        // Ensure consistent width for value text (8 characters)
+        if text.len() > 8 {
+            text[..8].to_string()
+        } else {
+            format!("{text:>8}")
+        }
+    } else {
+        format!("{:>7.1}%", total_ratio * 100.0)
+    };
+
+    // Print label
+    print_colored_text(stdout, &formatted_label, Color::White, None, None);
+    print_colored_text(stdout, ": [", Color::White, None, None);
+
+    // Calculate positioning for right-aligned text
+    let text_len = display_text.len();
+    let text_pos = available_bar_width.saturating_sub(text_len);
+
+    // Calculate segment positions
+    let mut segment_positions = Vec::new();
+    let mut current_pos = 0;
+
+    for segment in segments {
+        let segment_ratio = segment.value / max_value;
+        let segment_width = (available_bar_width as f64 * segment_ratio).round() as usize;
+        segment_positions.push((current_pos, current_pos + segment_width, segment.color));
+        current_pos += segment_width;
+    }
+
+    // Ensure we don't exceed the total filled width
+    let total_filled_width = (available_bar_width as f64 * total_ratio).round() as usize;
+    if current_pos > total_filled_width {
+        // Adjust the last segment to fit
+        if let Some(last) = segment_positions.last_mut() {
+            last.1 = total_filled_width;
+        }
+    }
+
+    // Print the bar with segments
+    for i in 0..available_bar_width {
+        if i >= text_pos && i < text_pos + text_len {
+            // Print text character
+            let char_index = i - text_pos;
+            if let Some(ch) = display_text.chars().nth(char_index) {
+                print_colored_text(stdout, &ch.to_string(), Color::White, None, None);
+            }
+        } else {
+            // Find which segment this position belongs to
+            let mut printed = false;
+            for &(start, end, color) in &segment_positions {
+                if i >= start && i < end {
+                    print_colored_text(stdout, "▬", color, None, None);
+                    printed = true;
+                    break;
+                }
+            }
+
+            if !printed {
+                // Print empty line segments
+                print_colored_text(stdout, "─", Color::DarkGrey, None, None);
+            }
+        }
+    }
+
+    print_colored_text(stdout, "]", Color::White, None, None);
+}
+
+// Helper functions for common use cases
+impl BarSegment {
+    // CPU usage helpers
+    pub fn cpu_low_priority(value: f64) -> Self {
+        Self::new(value, Color::Blue).with_label("low")
+    }
+
+    pub fn cpu_normal(value: f64) -> Self {
+        Self::new(value, Color::Green).with_label("normal")
+    }
+
+    pub fn cpu_kernel(value: f64) -> Self {
+        Self::new(value, Color::Red).with_label("kernel")
+    }
+
+    pub fn cpu_virtualized(value: f64) -> Self {
+        Self::new(value, Color::DarkBlue).with_label("virtual")
+    }
+
+    // Memory usage helpers
+    pub fn memory_used(value: f64) -> Self {
+        Self::new(value, Color::Green).with_label("used")
+    }
+
+    pub fn memory_buffers(value: f64) -> Self {
+        Self::new(value, Color::Blue).with_label("buffers")
+    }
+
+    pub fn memory_cache(value: f64) -> Self {
+        Self::new(value, Color::Yellow).with_label("cache")
+    }
 }


### PR DESCRIPTION
## Summary
- Added `draw_bar_multi` function to support stacked bar visualization with multiple colored segments
- Implemented stacked memory bar showing used (green), buffers (blue), and cache (yellow) in a single bar
- Added helper functions for creating common bar segments (CPU and memory types)
- Enhanced help screen with memory gauge legend and two-column layout

## Changes
1. **New `draw_bar_multi` function**: Renders multiple segments in a single progress bar, each with its own color
2. **`BarSegment` struct**: Represents individual segments with value, color, and optional label
3. **Memory display improvement**: Combined separate "Used" and "Cache" bars into a single stacked bar showing:
   - Actual used memory (excluding buffers/cache) in green
   - Buffer memory in blue
   - Cache memory in yellow
4. **Helper functions**: Added convenience methods for common segment types (reserved for future CPU usage implementation)
5. **Help screen enhancements**:
   - Added "Resource Gauge Legend" section explaining memory bar colors
   - Reorganized layout into two columns for better space utilization
   - Added consistent padding for improved readability

## Benefits
- Clearer visualization of memory composition at a glance
- Extensible design for future CPU usage breakdown (user/system/nice/steal)
- Consistent with standard memory monitoring tools that show memory breakdown
- Better help screen organization prevents content from being cut off

## Test plan
- [x] Code compiles without errors
- [x] All existing tests pass
- [x] Manual testing with mock server shows correct memory bar rendering
- [x] Help screen displays correctly with new layout
- [x] No breaking changes to existing functionality