### PR TITLE
fix: use fixed-width formatting for Apple Silicon GPU power display

### DIFF
--- a/src/ui/device_renderers.rs
+++ b/src/ui/device_renderers.rs
@@ -131,7 +131,8 @@ pub fn print_gpu_info<W: Write>(
         "N/A".to_string()
     } else if is_apple_silicon {
         // Apple Silicon GPU uses very little power, show 2 decimal places
-        format!("{:.2}W", info.power_consumption)
+        // Use fixed width formatting to prevent trailing characters
+        format!("{:5.2}W", info.power_consumption)
     } else if let Some(power_max_str) = info.detail.get("power_limit_max") {
         if let Ok(power_max) = power_max_str.parse::<f64>() {
             format!("{:.0}/{:.0}W", info.power_consumption, power_max)


### PR DESCRIPTION
## Summary
- Fixed trailing 'W' character issue in GPU power display (e.g., "0.20WW" instead of "0.20W")
- Applied fixed-width formatting for Apple Silicon GPU power values to ensure consistent string length

## Problem
The power display for Apple Silicon GPUs was showing variable-width decimal formatting (e.g., "0.2W" vs "0.20W"). When the terminal rendered a shorter string after a longer one, the trailing character wasn't properly cleared, resulting in duplicate 'W' characters.

## Solution
Changed the formatting from `{:.2}W` to `{:5.2}W` to ensure the power string always has the same length, preventing any trailing characters from previous renders.