### PR TITLE
feat: add animated progress bar to loading screen

### DIFF
--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use crossterm::{cursor, queue, style::Color};
 
 use crate::app_state::AppState;
-use crate::ui::constants::SCREEN_MARGIN;
+use crate::ui::constants::{ANIMATION_SPEED, BLOCK_SIZE_DIVISOR, BLOCK_SIZE_MAX, SCREEN_MARGIN};
 use crate::ui::text::{display_width, print_colored_text, truncate_to_width};
 
 pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, frame_counter: u64) {

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -21,7 +21,7 @@ pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, f
     let bar_y = y + 2; // 2 lines below "Loading..."
 
     // Create animated progress bar
-    let animation_speed = 3u64; // Lower = faster
+    let animation_speed = ANIMATION_SPEED; // Lower = faster
     let position = ((frame_counter / animation_speed) % (bar_width as u64 * 2)) as usize;
 
     // Calculate the sliding block position (ping-pong effect)

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -21,8 +21,8 @@ pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, f
     let bar_y = y + 2; // 2 lines below "Loading..."
 
     // Create animated progress bar
-    let animation_speed = ANIMATION_SPEED; // Lower = faster
-    let position = ((frame_counter / animation_speed) % (bar_width as u64 * 2)) as usize;
+    // Lower ANIMATION_SPEED = faster
+    let position = ((frame_counter / ANIMATION_SPEED) % (bar_width as u64 * 2)) as usize;
 
     // Calculate the sliding block position (ping-pong effect)
     let block_size = BLOCK_SIZE_MAX.min(bar_width / BLOCK_SIZE_DIVISOR); // Smaller block

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -5,7 +5,7 @@ use crossterm::{cursor, queue, style::Color};
 use crate::app_state::AppState;
 use crate::ui::text::{display_width, print_colored_text, truncate_to_width};
 
-pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16) {
+pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, frame_counter: u64) {
     // Center the loading message
     let message = "Loading...";
     let x = (cols.saturating_sub(message.len() as u16)) / 2;
@@ -13,6 +13,39 @@ pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16) {
 
     queue!(stdout, cursor::MoveTo(x, y)).unwrap();
     print_colored_text(stdout, message, Color::Yellow, None, None);
+
+    // Progress bar parameters
+    let bar_width = 40.min(cols as usize - 10); // Ensure it fits on screen
+    let bar_x = (cols.saturating_sub(bar_width as u16)) / 2;
+    let bar_y = y + 2; // 2 lines below "Loading..."
+
+    // Create animated progress bar
+    let animation_speed = 3u64; // Lower = faster (was 8, originally 20)
+    let position = ((frame_counter / animation_speed) % (bar_width as u64 * 2)) as usize;
+
+    // Calculate the sliding block position (ping-pong effect)
+    let block_size = 3.min(bar_width / 4); // Smaller block (was 5)
+    let actual_pos = if position < bar_width {
+        position
+    } else {
+        bar_width * 2 - position - 1
+    };
+
+    // Ensure the block doesn't go out of bounds
+    let block_start = actual_pos.min(bar_width.saturating_sub(block_size));
+    let block_end = (block_start + block_size).min(bar_width);
+
+    // Move to progress bar position
+    queue!(stdout, cursor::MoveTo(bar_x, bar_y)).unwrap();
+
+    // Draw the progress bar with thinner characters
+    for i in 0..bar_width {
+        if i >= block_start && i < block_end {
+            print_colored_text(stdout, "━", Color::Cyan, None, None);
+        } else {
+            print_colored_text(stdout, "─", Color::DarkGrey, None, None);
+        }
+    }
 }
 
 pub fn print_function_keys<W: Write>(

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -24,7 +24,7 @@ pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, f
     let position = ((frame_counter / animation_speed) % (bar_width as u64 * 2)) as usize;
 
     // Calculate the sliding block position (ping-pong effect)
-    let block_size = 3.min(bar_width / 4); // Smaller block (was 5)
+    let block_size = 3.min(bar_width / 4); // Smaller block
     let actual_pos = if position < bar_width {
         position
     } else {

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -25,7 +25,7 @@ pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, f
     let position = ((frame_counter / animation_speed) % (bar_width as u64 * 2)) as usize;
 
     // Calculate the sliding block position (ping-pong effect)
-    let block_size = 3.min(bar_width / 4); // Smaller block
+    let block_size = BLOCK_SIZE_MAX.min(bar_width / BLOCK_SIZE_DIVISOR); // Smaller block
     let actual_pos = if position < bar_width {
         position
     } else {

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use crossterm::{cursor, queue, style::Color};
 
 use crate::app_state::AppState;
+use crate::ui::constants::SCREEN_MARGIN;
 use crate::ui::text::{display_width, print_colored_text, truncate_to_width};
 
 pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, frame_counter: u64) {

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -15,7 +15,7 @@ pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, f
     print_colored_text(stdout, message, Color::Yellow, None, None);
 
     // Progress bar parameters
-    let bar_width = 40.min(cols as usize - 10); // Ensure it fits on screen
+    let bar_width = 40.min(cols as usize - SCREEN_MARGIN); // Ensure it fits on screen
     let bar_x = (cols.saturating_sub(bar_width as u16)) / 2;
     let bar_y = y + 2; // 2 lines below "Loading..."
 

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -25,7 +25,7 @@ pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, f
     let position = ((frame_counter / ANIMATION_SPEED) % (bar_width as u64 * 2)) as usize;
 
     // Calculate the sliding block position (ping-pong effect)
-    let block_size = BLOCK_SIZE_MAX.min(bar_width / BLOCK_SIZE_DIVISOR); // Smaller block
+    let block_size = BLOCK_SIZE_MAX.min(bar_width / BLOCK_SIZE_DIVISOR); // Calculate block size relative to bar width
     let actual_pos = if position < bar_width {
         position
     } else {

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -20,7 +20,7 @@ pub fn print_loading_indicator<W: Write>(stdout: &mut W, cols: u16, rows: u16, f
     let bar_y = y + 2; // 2 lines below "Loading..."
 
     // Create animated progress bar
-    let animation_speed = 3u64; // Lower = faster (was 8, originally 20)
+    let animation_speed = 3u64; // Lower = faster
     let position = ((frame_counter / animation_speed) % (bar_width as u64 * 2)) as usize;
 
     // Calculate the sliding block position (ping-pong effect)

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -1,0 +1,4 @@
+// UI-related constants
+
+/// Margin to ensure UI elements fit on screen
+pub const SCREEN_MARGIN: usize = 10;

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -2,3 +2,12 @@
 
 /// Margin to ensure UI elements fit on screen
 pub const SCREEN_MARGIN: usize = 10;
+
+/// Animation speed for loading indicator (lower = faster)
+pub const ANIMATION_SPEED: u64 = 3;
+
+/// Maximum size of the loading indicator block
+pub const BLOCK_SIZE_MAX: usize = 3;
+
+/// Divisor for calculating block size relative to bar width
+pub const BLOCK_SIZE_DIVISOR: usize = 4;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod buffer;
 pub mod chrome;
+pub mod constants;
 pub mod dashboard;
 pub mod device_renderers;
 pub mod help;

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -239,7 +239,7 @@ impl UiLoop {
     ) -> String {
         let mut buffer = BufferWriter::new();
         print_function_keys(&mut buffer, cols, rows, state, is_remote);
-        print_loading_indicator(&mut buffer, cols, rows);
+        print_loading_indicator(&mut buffer, cols, rows, state.frame_counter);
         buffer.get_buffer().to_string()
     }
 


### PR DESCRIPTION
## Summary
- Added an animated progress bar below the "Loading..." text to provide visual feedback while waiting
- Progress bar features a sliding animation that moves back and forth smoothly
- Uses thin Unicode characters (─ and ━) for a clean, modern appearance

## Changes
- Modified `print_loading_indicator` function to accept frame counter for animation
- Added progress bar rendering with configurable speed and size
- Updated UI loop to pass frame counter to loading indicator

## Visual Details
- Progress bar width: 40 characters (adjusts to screen size)
- Animation speed: Fast movement for responsive feel
- Block size: 3 characters sliding indicator
- Colors: Cyan active block on dark grey background