### PR TITLE
fix: display 1/1 nodes in local view mode instead of 0/1

### DIFF
--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -11,7 +11,7 @@ pub fn draw_system_view<W: Write>(stdout: &mut W, state: &AppState, cols: u16) {
     let box_width = (cols as usize).min(80);
 
     // Calculate cluster statistics
-    let is_local_mode = state.tabs.len() == 1
+    let is_local_mode = state.tabs.len() == 2  // "All" tab + local hostname
         || (state.tabs.len() <= 4 && state.tabs.contains(&"Process".to_string()));
     let total_nodes = if is_local_mode {
         1 // Local mode has 1 node

--- a/src/view/event_handler.rs
+++ b/src/view/event_handler.rs
@@ -42,8 +42,8 @@ pub async fn handle_key_event(key_event: KeyEvent, state: &mut AppState, args: &
 }
 
 fn handle_left_arrow(state: &mut AppState) {
-    // Check if we're in local mode (only one tab)
-    if state.tabs.len() == 1
+    // Check if we're in local mode ("All" tab + local hostname)
+    if state.tabs.len() == 2
         || (state.tabs.len() == 4 && state.tabs.contains(&"Process".to_string()))
     {
         // Local mode - handle horizontal scrolling for process list
@@ -72,8 +72,8 @@ fn handle_left_arrow(state: &mut AppState) {
 }
 
 fn handle_right_arrow(state: &mut AppState) {
-    // Check if we're in local mode (only one tab)
-    if state.tabs.len() == 1
+    // Check if we're in local mode ("All" tab + local hostname)
+    if state.tabs.len() == 2
         || (state.tabs.len() == 4 && state.tabs.contains(&"Process".to_string()))
     {
         // Local mode - handle horizontal scrolling for process list
@@ -334,7 +334,7 @@ pub async fn handle_mouse_event(
 
 fn handle_process_header_click(x: u16, y: u16, state: &mut AppState) {
     // Check if we're in local mode with process list visible
-    if state.tabs.len() != 1
+    if state.tabs.len() != 2  // "All" tab + local hostname
         && !(state.tabs.len() == 4 && state.tabs.contains(&"Process".to_string()))
     {
         return;


### PR DESCRIPTION
## Summary
- Fixed the Nodes panel in Cluster Overview to correctly display "1/1" instead of "0/1" when running in local mode
- Updated local mode detection logic to account for the "All" tab that is always present

## Changes
- Updated `is_local_mode` condition in dashboard to check for 2 tabs (All + local hostname) instead of 1
- Fixed event handler functions to use the same updated condition for local mode detection

## Test plan
- [x] Build the project with `cargo build --release`
- [x] Run in local mode: `sudo ./target/release/all-smi view`
- [x] Verify that the Nodes panel in Cluster Overview shows "1/1" instead of "0/1"
- [x] Verify that arrow key navigation still works correctly in local mode