### PR TITLE
feat: add color output to start-mock-cluster.sh for enhanced readability

### DIFF
--- a/start-mock-cluster.sh
+++ b/start-mock-cluster.sh
@@ -1,6 +1,50 @@
 #!/bin/bash
 # Script to start multiple mock server processes for large port ranges
 
+# Color support - check if colors should be disabled
+if [[ -n "${NO_COLOR}" ]] || [[ ! -t 1 ]]; then
+    # Colors disabled
+    RED=""
+    GREEN=""
+    YELLOW=""
+    BLUE=""
+    CYAN=""
+    MAGENTA=""
+    BOLD=""
+    RESET=""
+else
+    # ANSI color codes
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BLUE='\033[0;34m'
+    CYAN='\033[0;36m'
+    MAGENTA='\033[0;35m'
+    BOLD='\033[1m'
+    RESET='\033[0m'
+fi
+
+# Color printing functions
+error() {
+    echo -e "${RED}${BOLD}Error:${RESET} ${RED}$*${RESET}" >&2
+}
+
+success() {
+    echo -e "${GREEN}${BOLD}✓${RESET} ${GREEN}$*${RESET}"
+}
+
+warning() {
+    echo -e "${YELLOW}${BOLD}Warning:${RESET} ${YELLOW}$*${RESET}"
+}
+
+info() {
+    echo -e "${CYAN}$*${RESET}"
+}
+
+header() {
+    echo -e "${BLUE}${BOLD}$*${RESET}"
+}
+
 # Default values (matching mock server defaults)
 PORT_RANGE=""
 GPU_NAME="NVIDIA H200 141GB HBM3"
@@ -11,47 +55,44 @@ PORTS_PER_PROCESS=50
 
 # Function to show help
 show_help() {
-    cat << EOF
-Start or stop multiple mock server processes for large port ranges
-
-USAGE:
-    $(basename "$0") [OPTIONS]
-    $(basename "$0") stop
-
-COMMANDS:
-    stop                        Stop all running mock servers
-
-OPTIONS:
-    --port-range <range>        Port range, e.g., 10001-10010 or 10001
-    --gpu-name <name>           GPU name (default: $GPU_NAME)
-    --platform <type>           Platform type: nvidia, apple, jetson, intel, amd (default: $PLATFORM)
-    -o, --output <file>         Output CSV file name (default: $OUTPUT)
-    --failure-nodes <count>     Number of nodes to simulate random failures (default: $FAILURE_NODES)
-    --ports-per-process <num>   Maximum ports per process (default: $PORTS_PER_PROCESS, limited by system file descriptors)
-    -h, --help                  Show this help message
-
-EXAMPLES:
-    # Start 125 mock servers on ports 10001-10125
-    $(basename "$0") --port-range 10001-10125
-    
-    # Start with GPU name and failure simulation
-    $(basename "$0") --port-range 10001-10200 --gpu-name "NVIDIA A100" --failure-nodes 5
-    
-    # Stop all mock servers
-    $(basename "$0") stop
-
-EOF
+    echo -e "${BLUE}${BOLD}Start or stop multiple mock server processes for large port ranges${RESET}"
+    echo ""
+    echo -e "${YELLOW}${BOLD}USAGE:${RESET}"
+    echo -e "    $(basename "$0") [OPTIONS]"
+    echo -e "    $(basename "$0") stop"
+    echo ""
+    echo -e "${YELLOW}${BOLD}COMMANDS:${RESET}"
+    echo -e "    ${GREEN}stop${RESET}                        Stop all running mock servers"
+    echo ""
+    echo -e "${YELLOW}${BOLD}OPTIONS:${RESET}"
+    echo -e "    ${GREEN}--port-range${RESET} <range>        Port range, e.g., 10001-10010 or 10001"
+    echo -e "    ${GREEN}--gpu-name${RESET} <name>           GPU name (default: ${CYAN}$GPU_NAME${RESET})"
+    echo -e "    ${GREEN}--platform${RESET} <type>           Platform type: nvidia, apple, jetson, intel, amd (default: ${CYAN}$PLATFORM${RESET})"
+    echo -e "    ${GREEN}-o, --output${RESET} <file>         Output CSV file name (default: ${CYAN}$OUTPUT${RESET})"
+    echo -e "    ${GREEN}--failure-nodes${RESET} <count>     Number of nodes to simulate random failures (default: ${CYAN}$FAILURE_NODES${RESET})"
+    echo -e "    ${GREEN}--ports-per-process${RESET} <num>   Maximum ports per process (default: ${CYAN}$PORTS_PER_PROCESS${RESET}, limited by system file descriptors)"
+    echo -e "    ${GREEN}-h, --help${RESET}                  Show this help message"
+    echo ""
+    echo -e "${YELLOW}${BOLD}EXAMPLES:${RESET}"
+    echo -e "    ${MAGENTA}# Start 125 mock servers on ports 10001-10125${RESET}"
+    echo -e "    $(basename "$0") --port-range 10001-10125"
+    echo ""
+    echo -e "    ${MAGENTA}# Start with GPU name and failure simulation${RESET}"
+    echo -e "    $(basename "$0") --port-range 10001-10200 --gpu-name \"NVIDIA A100\" --failure-nodes 5"
+    echo ""
+    echo -e "    ${MAGENTA}# Stop all mock servers${RESET}"
+    echo -e "    $(basename "$0") stop"
 }
 
 # Check for stop command
 if [[ "$1" == "stop" ]]; then
-    echo "Stopping all mock servers..."
+    info "Stopping all mock servers..."
     pkill -f all-smi-mock-server
     KILLED=$?
     if [ $KILLED -eq 0 ]; then
-        echo "Mock servers stopped successfully"
+        success "Mock servers stopped successfully"
     else
-        echo "No mock servers were running"
+        info "No mock servers were running"
     fi
     exit $KILLED
 fi
@@ -88,7 +129,7 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         *)
-            echo "Unknown option: $1"
+            error "Unknown option: $1"
             show_help
             exit 1
             ;;
@@ -97,7 +138,7 @@ done
 
 # Check if port range is provided
 if [ -z "$PORT_RANGE" ]; then
-    echo "Error: --port-range is required"
+    error "--port-range is required"
     show_help
     exit 1
 fi
@@ -112,28 +153,28 @@ elif [[ "$PORT_RANGE" =~ ^[0-9]+$ ]]; then
     END_PORT="$PORT_RANGE"
     TOTAL_PORTS=1
 else
-    echo "Error: Invalid port range format. Use 'start-end' or single port number"
+    error "Invalid port range format. Use 'start-end' or single port number"
     exit 1
 fi
 
-echo "Starting mock cluster with $TOTAL_PORTS ports ($START_PORT-$END_PORT)"
-echo "Configuration:"
-echo "  GPU Name: $GPU_NAME"
-echo "  Platform: $PLATFORM"
-echo "  Failure Nodes: $FAILURE_NODES"
-echo "  Ports per Process: $PORTS_PER_PROCESS"
+header "Starting mock cluster with $TOTAL_PORTS ports ($START_PORT-$END_PORT)"
+header "Configuration:"
+info "  GPU Name: $GPU_NAME"
+info "  Platform: $PLATFORM"
+info "  Failure Nodes: $FAILURE_NODES"
+info "  Ports per Process: $PORTS_PER_PROCESS"
 
 # Calculate number of processes needed
 NUM_PROCESSES=$(( (TOTAL_PORTS + PORTS_PER_PROCESS - 1) / PORTS_PER_PROCESS ))
-echo "  Processes: $NUM_PROCESSES"
+info "  Processes: $NUM_PROCESSES"
 
 # Check file descriptor limit
 SOFT_LIMIT=$(ulimit -Sn)
 if [ $SOFT_LIMIT -lt 1024 ] && [ $PORTS_PER_PROCESS -gt 20 ]; then
     echo ""
-    echo "WARNING: Low file descriptor limit detected: $SOFT_LIMIT"
-    echo "  Each process can only handle ~20 ports with this limit."
-    echo "  To increase: ulimit -n 1024"
+    warning "Low file descriptor limit detected: $SOFT_LIMIT"
+    info "  Each process can only handle ~20 ports with this limit."
+    info "  To increase: ulimit -n 1024"
 fi
 
 # Clean up old temporary files
@@ -155,7 +196,7 @@ for i in $(seq 0 $((NUM_PROCESSES - 1))); do
         # Calculate start index for this process
         NODE_START_INDEX=$((1 + i * PORTS_PER_PROCESS))
         
-        echo "Starting process $((i + 1)): ports $PROCESS_START-$PROCESS_END (nodes starting from node-$(printf %04d $NODE_START_INDEX))"
+        info "Starting process $((i + 1)): ports $PROCESS_START-$PROCESS_END (nodes starting from node-$(printf %04d $NODE_START_INDEX))"
         
         # Build command with all arguments
         CMD="./target/release/all-smi-mock-server"
@@ -177,7 +218,7 @@ for i in $(seq 0 $((NUM_PROCESSES - 1))); do
 done
 
 # Wait a moment for all processes to start
-echo "Waiting for processes to start..."
+info "Waiting for processes to start..."
 sleep 2
 
 # Check if processes are running
@@ -189,23 +230,23 @@ for pid in "${PIDS[@]}"; do
 done
 
 if [ $RUNNING -eq 0 ]; then
-    echo "Error: No mock server processes started successfully"
+    error "No mock server processes started successfully"
     exit 1
 fi
 
-echo "$RUNNING/$NUM_PROCESSES processes started successfully"
+success "$RUNNING/$NUM_PROCESSES processes started successfully"
 
 # Combine all CSV files
-echo "Combining host files..."
+info "Combining host files..."
 if ls hosts_*.csv 1> /dev/null 2>&1; then
     cat hosts_*.csv > "$OUTPUT"
     rm -f hosts_*.csv
-    echo "Created $OUTPUT with $TOTAL_PORTS hosts"
+    success "Created $OUTPUT with $TOTAL_PORTS hosts"
 else
-    echo "Warning: No host CSV files found"
+    warning "No host CSV files found"
 fi
 
 echo ""
-echo "Mock cluster started with PIDs: ${PIDS[*]}"
-echo "To stop all servers, run: $(basename "$0") stop"
-echo "To view logs: ps aux | grep all-smi-mock-server"
+header "Mock cluster started with PIDs: ${PIDS[*]}"
+info "To stop all servers, run: $(basename "$0") stop"
+info "To view logs: ps aux | grep all-smi-mock-server"

--- a/start-mock-cluster.sh
+++ b/start-mock-cluster.sh
@@ -2,7 +2,7 @@
 # Script to start multiple mock server processes for large port ranges
 
 # Color support - check if colors should be disabled
-if [[ -n "${NO_COLOR}" ]] || [[ ! -t 1 ]]; then
+if { [[ -n "${NO_COLOR}" ]] && [[ ! "${NO_COLOR,,}" =~ ^(0|false)$ ]]; } || [[ ! -t 1 ]]; then
     # Colors disabled
     RED=""
     GREEN=""

--- a/start-mock-cluster.sh
+++ b/start-mock-cluster.sh
@@ -30,7 +30,7 @@ error() {
 }
 
 success() {
-    echo -e "${GREEN}${BOLD}✓${RESET} ${GREEN}$*${RESET}"
+    echo -e "${GREEN}${BOLD}[OK]${RESET} ${GREEN}$*${RESET}"
 }
 
 warning() {


### PR DESCRIPTION
## Summary
- Added ANSI color codes to enhance output readability in `start-mock-cluster.sh`
- Implemented color-coded messages for errors (red), success (green), warnings (yellow), and info (cyan)
- Added support for `NO_COLOR` environment variable to disable colors when needed

## Changes
- Added color constants and helper functions (`error()`, `success()`, `warning()`, `info()`, `header()`)
- Updated all output messages to use appropriate color functions
- Enhanced help message with colorful formatting
- Automatically disables colors when output is not to a terminal or when `NO_COLOR` is set

## Benefits
- Improves readability and usability for users running the script
- Makes errors and important messages stand out visually
- Maintains compatibility with environments that don't support colors

## Test plan
- [x] Tested help message displays with colors
- [x] Tested error messages show in red
- [x] Tested success messages show in green
- [x] Tested warning messages show in yellow
- [x] Tested info messages show in cyan
- [x] Verified NO_COLOR environment variable disables all colors
- [x] Tested starting and stopping mock servers with colored output

Fixes #32