### PR TITLE
fix: process list now uses all available vertical space without overlapping function keys

### DIFF
--- a/src/ui/buffer.rs
+++ b/src/ui/buffer.rs
@@ -21,17 +21,23 @@ use std::io::{stdout, Write};
 
 pub struct BufferWriter {
     buffer: String,
+    line_count: usize,
 }
 
 impl BufferWriter {
     pub fn new() -> Self {
         Self {
             buffer: String::with_capacity(1024 * 1024), // Pre-allocate 1MB
+            line_count: 0,
         }
     }
 
     pub fn get_buffer(&self) -> &str {
         &self.buffer
+    }
+
+    pub fn line_count(&self) -> usize {
+        self.line_count
     }
 }
 
@@ -39,6 +45,10 @@ impl Write for BufferWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let s = std::str::from_utf8(buf)
             .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid UTF-8"))?;
+
+        // Count newlines in the new content
+        self.line_count += s.matches('\n').count();
+
         self.buffer.push_str(s);
         Ok(buf.len())
     }

--- a/src/ui/process_renderer.rs
+++ b/src/ui/process_renderer.rs
@@ -137,7 +137,8 @@ pub fn print_process_info<W: Write>(
     // Calculate how many processes we can display
     // Reserve rows for header section: 1 for "Processes:" title, 1 for header, 1 for separator, 1 for blank line
     const RESERVED_HEADER_ROWS: usize = 4;
-    let available_rows_for_processes = (available_rows as usize).saturating_sub(RESERVED_HEADER_ROWS + footer_rows);
+    let available_rows_for_processes =
+        (available_rows as usize).saturating_sub(RESERVED_HEADER_ROWS + footer_rows);
     let end_index = (start_index + available_rows_for_processes).min(processes.len());
 
     // Print process information

--- a/src/ui/process_renderer.rs
+++ b/src/ui/process_renderer.rs
@@ -25,14 +25,15 @@ pub fn print_process_info<W: Write>(
     processes: &[ProcessInfo],
     selected_index: usize,
     start_index: usize,
-    half_rows: u16,
+    available_rows: u16,
     cols: u16,
     horizontal_scroll_offset: usize,
     current_user: &str,
     sort_criteria: &crate::app_state::SortCriteria,
     sort_direction: &crate::app_state::SortDirection,
 ) {
-    queue!(stdout, Print("\r\nProcesses:\r\n")).unwrap();
+    // Don't add extra newlines at the start - the caller should handle positioning
+    queue!(stdout, Print("Processes:\r\n")).unwrap();
 
     let width = cols as usize;
 
@@ -130,9 +131,13 @@ pub fn print_process_info<W: Write>(
     print_colored_text(stdout, &separator, Color::DarkGrey, None, None);
     queue!(stdout, Print("\r\n")).unwrap();
 
+    // Calculate how many rows are reserved for footer information
+    let footer_rows = 2usize; // "Showing..." line + "Active..." stats line
+
     // Calculate how many processes we can display
-    let available_rows = half_rows.saturating_sub(3) as usize; // Reserve 3 rows for header and separator
-    let end_index = (start_index + available_rows).min(processes.len());
+    // Reserve rows: 4 for "Processes:" + header + separator + 2 for footer (always shown at bottom)
+    let available_rows_for_processes = (available_rows as usize).saturating_sub(4 + footer_rows);
+    let end_index = (start_index + available_rows_for_processes).min(processes.len());
 
     // Print process information
     for i in start_index..end_index {
@@ -258,8 +263,21 @@ pub fn print_process_info<W: Write>(
         }
     }
 
+    // Calculate lines used so far
+    let mut lines_used = 4; // "Processes:" (1) + header (1) + separator (1) + blank line after header (1)
+    lines_used += end_index.saturating_sub(start_index); // actual process lines
+
+    // Fill empty space between processes and footer
+    let total_lines_before_footer = (available_rows as usize).saturating_sub(footer_rows);
+    while lines_used < total_lines_before_footer {
+        let clear_line = " ".repeat(width);
+        queue!(stdout, Print(&clear_line)).unwrap();
+        queue!(stdout, Print("\r\n")).unwrap();
+        lines_used += 1;
+    }
+
     // Show navigation info if there are more processes
-    if processes.len() > available_rows {
+    if processes.len() > available_rows_for_processes {
         let nav_info = format!(
             "Showing {}-{} of {} processes (Use ↑↓ to navigate, PgUp/PgDn for pages)",
             start_index + 1,
@@ -270,6 +288,14 @@ pub fn print_process_info<W: Write>(
         let padded_nav_info = format!("{nav_info:<width$}");
         print_colored_text(stdout, &padded_nav_info, Color::DarkGrey, None, None);
         queue!(stdout, Print("\r\n")).unwrap();
+        lines_used += 1;
+    } else if !processes.is_empty() {
+        // If all processes fit, still show a summary line
+        let nav_info = format!("Showing all {} processes", processes.len());
+        let padded_nav_info = format!("{nav_info:<width$}");
+        print_colored_text(stdout, &padded_nav_info, Color::DarkGrey, None, None);
+        queue!(stdout, Print("\r\n")).unwrap();
+        lines_used += 1;
     }
 
     // Show process statistics
@@ -287,21 +313,11 @@ pub fn print_process_info<W: Write>(
         let padded_stats = format!("{stats:<width$}");
         print_colored_text(stdout, &padded_stats, Color::Cyan, None, None);
         queue!(stdout, Print("\r\n")).unwrap();
+        lines_used += 1;
     }
 
-    // Clear any remaining lines from the process section to prevent artifacts
-    // This handles the case where processes are removed and old lines remain
-    let mut lines_used = 3; // header (2) + separator (1)
-    lines_used += end_index.saturating_sub(start_index); // actual process lines
-    if processes.len() > available_rows {
-        lines_used += 1; // navigation info line
-    }
-    if !processes.is_empty() {
-        lines_used += 1; // stats line
-    }
-
-    // Clear any remaining lines up to the full half_rows allocation
-    while lines_used < half_rows as usize {
+    // Fill remaining space up to available_rows
+    while lines_used < available_rows as usize {
         let clear_line = " ".repeat(width);
         queue!(stdout, Print(&clear_line)).unwrap();
         queue!(stdout, Print("\r\n")).unwrap();

--- a/src/ui/process_renderer.rs
+++ b/src/ui/process_renderer.rs
@@ -135,8 +135,9 @@ pub fn print_process_info<W: Write>(
     let footer_rows = 2usize; // "Showing..." line + "Active..." stats line
 
     // Calculate how many processes we can display
-    // Reserve rows: 4 for "Processes:" + header + separator + 2 for footer (always shown at bottom)
-    let available_rows_for_processes = (available_rows as usize).saturating_sub(4 + footer_rows);
+    // Reserve rows for header section: 1 for "Processes:" title, 1 for header, 1 for separator, 1 for blank line
+    const RESERVED_HEADER_ROWS: usize = 4;
+    let available_rows_for_processes = (available_rows as usize).saturating_sub(RESERVED_HEADER_ROWS + footer_rows);
     let end_index = (start_index + available_rows_for_processes).min(processes.len());
 
     // Print process information

--- a/src/ui/process_renderer.rs
+++ b/src/ui/process_renderer.rs
@@ -265,7 +265,7 @@ pub fn print_process_info<W: Write>(
     }
 
     // Calculate lines used so far
-    let mut lines_used = 4; // "Processes:" (1) + header (1) + separator (1) + blank line after header (1)
+    let mut lines_used = 3; // "Processes:" (1) + header (1) + separator (1)
     lines_used += end_index.saturating_sub(start_index); // actual process lines
 
     // Fill empty space between processes and footer

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -672,8 +672,8 @@ impl UiLoop {
             };
 
             // Calculate how many lines have been used so far
-            // Count newlines in the buffer to determine current row position
-            let lines_used = buffer.get_buffer().matches('\n').count();
+            // Use the efficient line counter from BufferWriter
+            let lines_used = buffer.line_count();
 
             // Add a blank line before process list
             queue!(buffer, Print("\r\n")).unwrap();

--- a/src/view/ui_loop.rs
+++ b/src/view/ui_loop.rs
@@ -22,7 +22,7 @@ use crossterm::{
     cursor,
     event::{self, Event},
     queue,
-    style::Color,
+    style::{Color, Print},
     terminal::size,
 };
 use tokio::sync::Mutex;
@@ -670,7 +670,21 @@ impl UiLoop {
                     AppConfig::DEFAULT_TERMINAL_HEIGHT,
                 ),
             };
-            let half_rows = rows / 2;
+
+            // Calculate how many lines have been used so far
+            // Count newlines in the buffer to determine current row position
+            let lines_used = buffer.get_buffer().matches('\n').count();
+
+            // Add a blank line before process list
+            queue!(buffer, Print("\r\n")).unwrap();
+
+            // Reserve 1 line for function keys at the bottom
+            let function_key_rows = 1;
+
+            // Calculate available rows for process list
+            // Use all remaining space from current position to the function keys
+            // Account for the blank line we just added
+            let available_rows = rows.saturating_sub(lines_used as u16 + 1 + function_key_rows);
 
             // Get current user for process coloring
             let current_user = whoami::username();
@@ -680,7 +694,7 @@ impl UiLoop {
                 &state.process_info,
                 state.selected_process_index,
                 state.start_index,
-                half_rows,
+                available_rows,
                 cols,
                 state.process_horizontal_scroll_offset,
                 &current_user,


### PR DESCRIPTION
## Summary
- Fixed process list height calculation to use all available vertical space
- Ensured function keys remain visible at the bottom of the screen
- Process list footer (showing/active stats) now positioned correctly even with few processes

## Test plan
- [x] Run `all-smi view` in local mode
- [x] Verify process list fills entire available space below device info
- [x] Verify function keys are always visible at the bottom
- [x] Test with many processes (scrolling works correctly)
- [x] Test with few processes (footer lines positioned at bottom of process area)
- [x] Resize terminal and verify layout adapts correctly