### PR TITLE
feat: separate local and remote monitoring into distinct commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  clean                        Clean build artifacts"
 
 local:
-	cargo run --bin all-smi -- view 
+	cargo run --bin all-smi -- local
 
 api:
 	cargo run --bin all-smi -- api
@@ -67,7 +67,7 @@ docker-test-container-view:
 		rust:1.88 \
 		/bin/bash -c "apt-get update && apt-get install -y pkg-config protobuf-compiler && \
 		cargo build --release && \
-		./target/release/all-smi view"
+		./target/release/all-smi local"
 
 docker-build-container:
 	@mkdir -p tests/.cargo-cache

--- a/README.md
+++ b/README.md
@@ -90,41 +90,44 @@ See [Building from Source](DEVELOPERS.md#building-from-source) in the developer 
 # Show help
 all-smi --help
 
-# Local monitoring (requires sudo on macOS)
-sudo all-smi view
+# Local monitoring (requires sudo on macOS) - default when no command specified
+all-smi
+sudo all-smi local
 
-# Remote monitoring
+# Remote monitoring (requires API endpoints)
 all-smi view --hosts http://node1:9090 http://node2:9090
 all-smi view --hostfile hosts.csv
 
-# API mode
+# API mode (expose metrics server)
 all-smi api --port 9090
 ```
 
-### View Mode (Interactive Monitoring)
+### Local Mode (Monitor Local Hardware)
 
-The `view` mode provides a terminal-based interface with real-time updates.
+The `local` mode monitors your local GPUs/NPUs with a terminal-based interface. This is the default when no command is specified.
 
-#### Local Mode
 ```bash
 # Monitor local GPUs (requires sudo on macOS)
-sudo all-smi view
+all-smi              # Default to local mode
+sudo all-smi local   # Explicit local mode
 
 # With custom refresh interval
-sudo all-smi view --interval 5
+sudo all-smi local --interval 5
 ```
 
-#### Remote Monitoring
+### Remote View Mode (Monitor Remote Nodes)
 
-Monitor multiple remote systems running in API mode:
+The `view` mode monitors multiple remote systems that are running in API mode. This mode requires specifying remote endpoints.
 
 ```bash
-# Direct host specification
+# Direct host specification (required)
 all-smi view --hosts http://gpu-node1:9090 http://gpu-node2:9090
 
-# Using host file
+# Using host file (required)
 all-smi view --hostfile hosts.csv --interval 2
 ```
+
+**Note:** The `view` command requires either `--hosts` or `--hostfile`. For local monitoring, use `all-smi local` instead.
 
 Host file format (CSV):
 ```
@@ -285,7 +288,7 @@ For development and testing, you can use the provided Makefile:
 # Run local monitoring
 make local
 
-# Run remote monitoring with hosts file
+# Run remote view mode with hosts file
 make remote
 
 # Start mock server for testing

--- a/docs/man/all-smi.1
+++ b/docs/man/all-smi.1
@@ -3,7 +3,10 @@
 all-smi \- Command-line utility for monitoring GPU hardware
 .SH SYNOPSIS
 .B all-smi
-[\fBview\fR] [\fIOPTIONS\fR]
+[\fBlocal\fR] [\fIOPTIONS\fR]
+.br
+.B all-smi
+\fBview\fR --hosts \fIURL\fR... | --hostfile \fIFILE\fR [\fIOPTIONS\fR]
 .br
 .B all-smi
 \fBapi\fR [\fIOPTIONS\fR]
@@ -16,18 +19,25 @@ is a comprehensive hardware monitoring tool that provides real-time information 
 memory usage, temperature, power consumption, and other metrics. It supports various hardware platforms 
 including NVIDIA GPUs, Apple Silicon, NVIDIA Jetson, Tenstorrent NPUs, Rebellions NPUs, and Furiosa NPUs.
 
-The tool can run in two primary modes:
+The tool can run in three primary modes:
+.TP
+.B local mode
+An interactive TUI for monitoring local GPUs/NPUs (default when no command specified)
 .TP
 .B view mode
-An interactive terminal user interface (TUI) for real-time monitoring
+An interactive TUI for monitoring remote nodes via API endpoints
 .TP
 .B api mode
 A Prometheus-compatible metrics endpoint for integration with monitoring systems
 .SH COMMANDS
 .TP
-.B view
-Run in view mode, displaying an interactive TUI. This is the default mode if no command is specified.
+.B local
+Run in local mode, monitoring local GPUs/NPUs with an interactive TUI. This is the default mode if no command is specified.
 Requires sudo permissions on macOS for Apple Silicon metrics.
+.TP
+.B view
+Run in remote view mode, monitoring remote nodes via API endpoints. Requires either --hosts or --hostfile option.
+Does not require sudo permissions.
 .TP
 .B api
 Run in API mode, exposing metrics in Prometheus format via HTTP endpoint.
@@ -43,22 +53,25 @@ Display help information
 .TP
 .B \-V, \-\-version
 Display version information
-.SS View Mode Options
+.SS Local Mode Options
+.TP
+.B \-i, \-\-interval \fISECONDS\fR
+The interval in seconds at which to update the hardware information.
+Default: 1 second (Apple Silicon) or 2 seconds (others)
+.SS View Mode Options (Remote Monitoring)
 .TP
 .B \-\-hosts \fIURL\fR...
-A list of host addresses to connect to for remote monitoring. Multiple hosts can be specified.
+(Required) A list of host addresses to connect to for remote monitoring. Multiple hosts can be specified.
 Format: http://hostname:port or https://hostname:port
 .TP
 .B \-\-hostfile \fIFILE\fR
-A CSV file containing a list of host addresses to connect to for remote monitoring.
-The file should contain one URL per line.
+(Required) A CSV file containing a list of host addresses to connect to for remote monitoring.
+The file should contain one URL per line. Either this or --hosts must be specified.
 .TP
 .B \-i, \-\-interval \fISECONDS\fR
 The interval in seconds at which to update the hardware information. 
 If not specified, uses adaptive interval based on node count:
 .RS
-.IP \(bu 3
-Local monitoring: 1 second (Apple Silicon) or 2 seconds (others)
 .IP \(bu 3
 1-10 remote nodes: 3 seconds
 .IP \(bu 3
@@ -78,7 +91,7 @@ The interval in seconds at which to update the hardware information (default: 3)
 .TP
 .B \-\-processes
 Include the process list in the API output
-.SH INTERACTIVE CONTROLS (VIEW MODE)
+.SH INTERACTIVE CONTROLS (LOCAL/VIEW MODE)
 .TP
 .B Tab / Shift+Tab
 Navigate between different tabs (GPU, CPU, Memory, Network, Disk)
@@ -134,12 +147,12 @@ Prometheus-compatible metrics endpoint with hardware statistics
 Health check endpoint returning "OK"
 .SH EXAMPLES
 .TP
-View local hardware in interactive TUI:
+Monitor local hardware in interactive TUI:
 .B all-smi
 .br
 or
 .br
-.B all-smi view
+.B all-smi local
 .TP
 Start API server on default port 9090:
 .B all-smi api
@@ -147,7 +160,10 @@ Start API server on default port 9090:
 Start API server on custom port with 5-second interval:
 .B all-smi api --port 8080 --interval 5
 .TP
-Monitor remote hosts:
+Monitor local hardware with custom interval:
+.B all-smi local --interval 5
+.TP
+Monitor remote hosts (requires API endpoints):
 .B all-smi view --hosts http://node1:9090 http://node2:9090
 .TP
 Monitor hosts from file:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,9 @@ pub struct Cli {
 pub enum Commands {
     /// Run in API mode, exposing metrics in Prometheus format.
     Api(ApiArgs),
-    /// Run in view mode, displaying a TUI. (default)
+    /// Run in local mode, monitoring local GPUs/NPUs. (default)
+    Local(LocalArgs),
+    /// Run in remote view mode, monitoring remote nodes via API endpoints.
     View(ViewArgs),
 }
 
@@ -40,6 +42,13 @@ pub struct ApiArgs {
     /// Include the process list in the API output.
     #[arg(long)]
     pub processes: bool,
+}
+
+#[derive(Parser, Clone)]
+pub struct LocalArgs {
+    /// The interval in seconds at which to update the GPU information.
+    #[arg(short, long)]
+    pub interval: Option<u64>,
 }
 
 #[derive(Parser, Clone)]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -272,8 +272,9 @@ fn render_terminal_section(line_idx: usize, width: usize) -> String {
         ("", "", "separator"),
         ("", "", ""),
         ("Local Monitoring:", "", "header"),
+        ("  all-smi", "Monitor local GPUs (default mode)", "command"),
         (
-            "  sudo all-smi view",
+            "  sudo all-smi local",
             "Monitor local GPUs (requires sudo on macOS)",
             "command",
         ),

--- a/src/view/runner.rs
+++ b/src/view/runner.rs
@@ -17,18 +17,62 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::app_state::AppState;
-use crate::cli::ViewArgs;
+use crate::cli::{LocalArgs, ViewArgs};
 use crate::view::{
     data_collector::DataCollector, terminal_manager::TerminalManager, ui_loop::UiLoop,
 };
 
-pub async fn run_view_mode(args: &ViewArgs) {
-    // Initialize application state
+pub async fn run_local_mode(args: &LocalArgs) {
+    // Initialize application state for local mode
     let mut initial_state = AppState::new();
+    initial_state.is_local_mode = true;
+    let app_state = Arc::new(Mutex::new(initial_state));
 
-    // Set mode based on CLI arguments
-    initial_state.is_local_mode = args.hosts.is_none() && args.hostfile.is_none();
+    // Initialize terminal
+    let _terminal_manager = match TerminalManager::new() {
+        Ok(manager) => manager,
+        Err(e) => {
+            eprintln!("Failed to initialize terminal: {e}");
+            return;
+        }
+    };
 
+    // Start data collection in background
+    let data_collector = DataCollector::new(Arc::clone(&app_state));
+    let view_args = ViewArgs {
+        hosts: None,
+        hostfile: None,
+        interval: args.interval,
+    };
+    tokio::spawn(async move {
+        data_collector.run_local_mode(view_args).await;
+    });
+
+    // Run UI loop
+    let mut ui_loop = match UiLoop::new(app_state) {
+        Ok(ui_loop) => ui_loop,
+        Err(e) => {
+            eprintln!("Failed to initialize UI: {e}");
+            return;
+        }
+    };
+
+    let view_args = ViewArgs {
+        hosts: None,
+        hostfile: None,
+        interval: args.interval,
+    };
+    if let Err(e) = ui_loop.run(&view_args).await {
+        eprintln!("UI loop error: {e}");
+    }
+
+    // Terminal cleanup is handled by TerminalManager's Drop trait
+}
+
+pub async fn run_view_mode(args: &ViewArgs) {
+    // Initialize application state for remote mode
+    let mut initial_state = AppState::new();
+    initial_state.is_local_mode = false;
     let app_state = Arc::new(Mutex::new(initial_state));
 
     // Initialize terminal
@@ -47,15 +91,10 @@ pub async fn run_view_mode(args: &ViewArgs) {
         let hosts = args_clone.hosts.clone().unwrap_or_default();
         let hostfile = args_clone.hostfile.clone();
 
-        if hosts.is_empty() && hostfile.is_none() {
-            // Local mode
-            data_collector.run_local_mode(args_clone).await;
-        } else {
-            // Remote mode
-            data_collector
-                .run_remote_mode(args_clone, hosts, hostfile)
-                .await;
-        }
+        // Remote mode
+        data_collector
+            .run_remote_mode(args_clone, hosts, hostfile)
+            .await;
     });
 
     // Run UI loop


### PR DESCRIPTION
## Summary

This PR separates the monitoring functionality into two distinct commands for better clarity and user experience:
- `local` command: Explicitly for monitoring local GPUs/NPUs (default when no command specified)
- `view` command: Exclusively for remote monitoring (requires --hosts or --hostfile)

## Changes

- Added new `local` command with `LocalArgs` struct for local hardware monitoring
- Modified `view` command to require either `--hosts` or `--hostfile` for remote monitoring
- Updated default behavior to run in local mode when no command is specified
- Split `run_view_mode()` into `run_local_mode()` and `run_view_mode()` functions
- Updated all documentation (README, man page, UI help) to reflect the new command structure
- Modified Makefile targets to use the appropriate commands

## Motivation

Previously, the `view` command handled both local and remote monitoring depending on whether hosts were specified. This implicit behavior could be confusing. The new structure makes it explicit:
- Use `all-smi` or `all-smi local` for local monitoring
- Use `all-smi view --hosts ...` for remote monitoring

## Breaking Changes

- The `view` command now requires either `--hosts` or `--hostfile` options
- Users who previously used `all-smi view` for local monitoring should now use `all-smi local` or just `all-smi`

## Testing

- Tested local monitoring with `all-smi` and `all-smi local`
- Tested remote monitoring with `all-smi view --hosts` and `all-smi view --hostfile`
- Verified error message when `view` is used without required options
- All existing functionality remains intact