### PR TITLE
fix: ensure fixed width for hostname display in device lists

### DIFF
--- a/src/ui/device_renderers.rs
+++ b/src/ui/device_renderers.rs
@@ -22,6 +22,7 @@ use crate::ui::text::{print_colored_text, truncate_to_width};
 use crate::ui::widgets::{draw_bar, draw_bar_multi, BarSegment};
 
 /// Formats a hostname for display with scrolling animation if it exceeds 9 characters
+/// Always returns a string with exactly 9 characters (padded with spaces if needed)
 fn format_hostname_with_scroll(hostname: &str, scroll_offset: usize) -> String {
     if hostname.len() > 9 {
         let scroll_len = hostname.len() + 3;
@@ -33,7 +34,8 @@ fn format_hostname_with_scroll(hostname: &str, scroll_offset: usize) -> String {
             .take(9)
             .collect::<String>()
     } else {
-        hostname.to_string()
+        // Always return 9 characters, left-aligned with space padding
+        format!("{hostname:<9}")
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixed inconsistent hostname column width in remote view mode
- Ensures all hostnames display with consistent 9-character width

## Problem
When monitoring multiple hosts with different name lengths (e.g., "main1" and "sub1"), the hostname column width was variable, causing misalignment in the display.

## Solution
Modified `format_hostname_with_scroll` function to always return a 9-character fixed-width string:
- Hostnames longer than 9 characters: Continue scrolling animation (unchanged)
- Hostnames 9 characters or shorter: Now padded with spaces to maintain fixed width

## Test plan
- [x] Build and run with `cargo build --release`
- [x] Test with hosts of different name lengths
- [x] Verify consistent column alignment across GPU, CPU, Memory, and Disk lists
- [x] Confirm scrolling still works for long hostnames